### PR TITLE
Wire up view, bless & burn actions

### DIFF
--- a/thisrightnow/src/abi/BlessBurnTracker.json
+++ b/thisrightnow/src/abi/BlessBurnTracker.json
@@ -1,0 +1,28 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "blessPost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "burnPost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/abi/ViewIndex.json
+++ b/thisrightnow/src/abi/ViewIndex.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "logView",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -1,23 +1,65 @@
 import { useState } from 'react';
+import { ethers } from 'ethers';
+import ViewIndexABI from '../abi/ViewIndex.json';
+import BlessBurnTrackerABI from '../abi/BlessBurnTracker.json';
 
-export default function PostCard({ post, user: _ }: any) {
+interface Post {
+  hash: string;
+  title: string;
+  content: string;
+}
+
+const VIEW_INDEX_ADDR = '0xYourViewIndexAddress';
+const BLESS_BURN_ADDR = '0xYourBlessBurnAddress';
+
+export default function PostCard({ post, user }: { post: Post; user: string }) {
   const [viewed, setViewed] = useState(false);
   const [blessed, setBlessed] = useState(false);
   const [burned, setBurned] = useState(false);
 
-  const handleView = () => {
-    // call ViewIndex.logView(post.hash)
-    setViewed(true);
+  const handleView = async () => {
+    if (!user || viewed) return;
+    try {
+      const provider = new ethers.BrowserProvider(
+        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+      );
+      const signer = await provider.getSigner();
+      const contract = new ethers.Contract(VIEW_INDEX_ADDR, ViewIndexABI, signer);
+      await contract.logView(post.hash);
+      setViewed(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
-  const handleBless = () => {
-    // call BlessBurnTracker.blessPost(post.hash)
-    setBlessed(true);
+  const handleBless = async () => {
+    if (!user || blessed) return;
+    try {
+      const provider = new ethers.BrowserProvider(
+        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+      );
+      const signer = await provider.getSigner();
+      const contract = new ethers.Contract(BLESS_BURN_ADDR, BlessBurnTrackerABI, signer);
+      await contract.blessPost(post.hash);
+      setBlessed(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
-  const handleBurn = () => {
-    // call BlessBurnTracker.burnPost(post.hash)
-    setBurned(true);
+  const handleBurn = async () => {
+    if (!user || burned) return;
+    try {
+      const provider = new ethers.BrowserProvider(
+        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+      );
+      const signer = await provider.getSigner();
+      const contract = new ethers.Contract(BLESS_BURN_ADDR, BlessBurnTrackerABI, signer);
+      await contract.burnPost(post.hash);
+      setBurned(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   return (

--- a/thisrightnow/src/hooks/useTRN.ts
+++ b/thisrightnow/src/hooks/useTRN.ts
@@ -10,10 +10,12 @@ export function useTRNBalance(address: string) {
   useEffect(() => {
     if (!address) return;
 
-    const provider = new ethers.BrowserProvider((window as any).ethereum);
+    const provider = new ethers.BrowserProvider(
+      (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+    );
     const contract = new ethers.Contract(TRN_USAGE_ORACLE, ABI, provider);
 
-    contract.getAvailableTRN(address).then((res: any) => {
+    contract.getAvailableTRN(address).then((res) => {
       setBalance(res.toString());
     });
   }, [address]);

--- a/thisrightnow/src/pages/index.tsx
+++ b/thisrightnow/src/pages/index.tsx
@@ -12,7 +12,7 @@ export default function Home() {
       <ConnectButton />
       <div className="mt-6">
         {mockPosts.map((post) => (
-          <PostCard key={post.hash} post={post} user={address} />
+          <PostCard key={post.hash} post={post} user={address ?? ''} />
         ))}
       </div>
     </div>

--- a/thisrightnow/src/utils/contract.ts
+++ b/thisrightnow/src/utils/contract.ts
@@ -1,7 +1,9 @@
 import { ethers } from 'ethers';
 
-export async function loadContract(address: string, abi: any) {
-  const provider = new ethers.BrowserProvider((window as any).ethereum);
+export async function loadContract(address: string, abi: ethers.InterfaceAbi) {
+  const provider = new ethers.BrowserProvider(
+    (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+  );
   const signer = await provider.getSigner();
   return new ethers.Contract(address, abi, signer);
 }


### PR DESCRIPTION
## Summary
- add minimal ABIs for ViewIndex and BlessBurnTracker
- use ethers to log views, blesses, and burns in `PostCard`
- type cleanup and helper updates
- handle optional wallet address in Home page

## Testing
- `npm run lint` in `thisrightnow`
- `npm run build` in `thisrightnow`
- `npm test` in `ado-core` *(fails: Option 'moduleResolution' must be set to 'NodeNext')*

------
https://chatgpt.com/codex/tasks/task_e_68531fa2483883339baaf79d58e98860