### PR TITLE
Add initial indexer scaffold

### DIFF
--- a/indexer/README.md
+++ b/indexer/README.md
@@ -1,3 +1,16 @@
 # Indexer
 
-Services for capturing on-chain events and building Merkle proofs for airdrops and rewards.
+This package contains utilities for listening to on-chain events and building
+Merkle proofs for payouts. The initial scaffold listens to `ViewIndex.ViewLogged`
+events, deduplicates unique views per user and post per day and builds a Merkle
+root of the eligible earnings. Results are written to the `output/` directory
+as JSON files.
+
+```
+indexer/
+├── viewIndexer.ts       # Event listener and view logger
+├── dedupe.ts            # Deduplication helpers
+├── buildMerkle.ts       # Merkle tree builder
+├── types.ts             # Shared TypeScript types
+└── output/              # Generated data files
+```

--- a/indexer/abis/ViewIndex.json
+++ b/indexer/abis/ViewIndex.json
@@ -1,0 +1,64 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "viewer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "ViewLogged",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "logView",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "viewer",
+        "type": "address"
+      }
+    ],
+    "name": "hasUserViewed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/indexer/buildMerkle.ts
+++ b/indexer/buildMerkle.ts
@@ -1,0 +1,31 @@
+// indexer/buildMerkle.ts
+import keccak256 from "keccak256";
+import { MerkleTree } from "merkletreejs";
+import fs from "fs";
+
+export function buildMerkleFromViews(viewData: any[]) {
+  const leaves = viewData.map((v) =>
+    keccak256(`${v.viewer.toLowerCase()}-${v.postHash}`)
+  );
+
+  const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
+  const root = tree.getHexRoot();
+
+  fs.writeFileSync(
+    `./output/merkle-${new Date().toISOString().split("T")[0]}.json`,
+    JSON.stringify(
+      {
+        merkleRoot: root,
+        leaves: leaves.map((l, i) => ({
+          viewer: viewData[i].viewer,
+          postHash: viewData[i].postHash,
+          leaf: `0x${l.toString("hex")}`,
+        })),
+      },
+      null,
+      2
+    )
+  );
+
+  return root;
+}

--- a/indexer/dedupe.ts
+++ b/indexer/dedupe.ts
@@ -1,0 +1,17 @@
+// indexer/dedupe.ts
+type ViewEvent = { postHash: string; viewer: string; timestamp: number };
+
+export function dedupeViews(rawViews: ViewEvent[]): ViewEvent[] {
+  const seen = new Set<string>();
+  const result: ViewEvent[] = [];
+
+  for (const v of rawViews) {
+    const key = `${v.postHash}-${v.viewer}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(v);
+    }
+  }
+
+  return result;
+}

--- a/indexer/output/merkle-2025-06-18.json
+++ b/indexer/output/merkle-2025-06-18.json
@@ -1,0 +1,4 @@
+{
+  "merkleRoot": "0x",
+  "leaves": []
+}

--- a/indexer/types.ts
+++ b/indexer/types.ts
@@ -1,0 +1,6 @@
+// indexer/types.ts
+export type ViewLog = {
+  postHash: string;
+  viewer: string;
+  timestamp: number;
+};

--- a/indexer/viewIndexer.ts
+++ b/indexer/viewIndexer.ts
@@ -1,0 +1,32 @@
+import { ethers } from "ethers";
+import ViewIndexABI from "./abis/ViewIndex.json";
+import fs from "fs";
+import { dedupeViews } from "./dedupe";
+
+const provider = new ethers.JsonRpcProvider("http://localhost:8545");
+const contract = new ethers.Contract("0xYourViewIndexAddress", ViewIndexABI, provider);
+
+const views: {
+  [day: string]: { postHash: string; viewer: string; timestamp: number }[];
+} = {};
+
+contract.on("ViewLogged", (viewer: string, postHash: string, timestamp: ethers.BigNumberish) => {
+  const day = new Date(Number(timestamp) * 1000).toISOString().split("T")[0];
+
+  if (!views[day]) views[day] = [];
+  views[day].push({
+    postHash,
+    viewer,
+    timestamp: Number(timestamp),
+  });
+
+  console.log(`[${day}] View recorded for post ${postHash} by ${viewer}`);
+});
+
+// Optionally dump raw + deduped view data
+setInterval(() => {
+  const today = new Date().toISOString().split("T")[0];
+  const deduped = dedupeViews(views[today] || []);
+  fs.writeFileSync(`./output/views-${today}.json`, JSON.stringify(deduped, null, 2));
+  console.log(`✅ Wrote ${deduped.length} deduped views to views-${today}.json`);
+}, 60000);


### PR DESCRIPTION
## Summary
- scaffold indexer utilities for capturing `ViewIndex.ViewLogged` events
- deduplicate views per user & post
- generate Merkle trees from deduped data and output JSON
- document indexer directory

## Testing
- `npm test` *(fails: needs hardhat installation)*

------
https://chatgpt.com/codex/tasks/task_e_6853264834c88333ade282ff2eafd861