### PR TITLE
Add RetrnScoreEngine and basic unit test

### DIFF
--- a/indexer/RetrnScoreEngine.ts
+++ b/indexer/RetrnScoreEngine.ts
@@ -1,0 +1,46 @@
+import { loadContract } from "./contract";
+import RetrnIndexABI from "./abis/RetrnIndex.json";
+import { getTrustScore } from "./TrustScoreEngine";
+
+export type Node = {
+  hash: string;
+  depth: number;
+  trust: number;
+  children: Node[];
+};
+
+export async function buildRetrnTree(rootHash: string, depth = 0): Promise<Node> {
+  const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+  const retrns: string[] = await contract.getRetrns(rootHash);
+
+  const children = await Promise.all(
+    retrns.map(async (hash) => {
+      const trust = await getTrustScore(hash);
+      const subtree = await buildRetrnTree(hash, depth + 1);
+      return { ...subtree, trust } as Node;
+    })
+  );
+
+  return {
+    hash: rootHash,
+    depth,
+    trust: await getTrustScore(rootHash),
+    children,
+  };
+}
+
+export function flattenTree(node: Node): Node[] {
+  return [node, ...node.children.flatMap(flattenTree)];
+}
+
+export function calcResonanceScore(root: Node): number {
+  const all = flattenTree(root);
+
+  let score = 0;
+  for (const node of all) {
+    const weight = 1 + node.depth; // depth bonus
+    score += weight * node.trust;
+  }
+
+  return Math.floor(score);
+}

--- a/indexer/TrustScoreEngine.ts
+++ b/indexer/TrustScoreEngine.ts
@@ -1,0 +1,5 @@
+// Placeholder trust score engine
+export async function getTrustScore(_hash: string): Promise<number> {
+  // In a real implementation this would query on-chain data or analytics.
+  return 1;
+}

--- a/indexer/abis/RetrnIndex.json
+++ b/indexer/abis/RetrnIndex.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrns",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/indexer/contract.ts
+++ b/indexer/contract.ts
@@ -1,0 +1,10 @@
+import { ethers } from "ethers";
+
+export async function loadContract(name: string, abi: ethers.InterfaceAbi) {
+  const provider = new ethers.JsonRpcProvider(
+    process.env.RPC_URL || "http://localhost:8545"
+  );
+  const address =
+    process.env[`${name.toUpperCase()}_ADDRESS`] || "0xYourContractAddress";
+  return new ethers.Contract(address, abi, provider);
+}

--- a/test/RetrnScoreEngine.test.ts
+++ b/test/RetrnScoreEngine.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { calcResonanceScore, Node } from '../indexer/RetrnScoreEngine';
+
+const tree: Node = {
+  hash: 'root',
+  depth: 0,
+  trust: 3,
+  children: [
+    {
+      hash: 'c1',
+      depth: 1,
+      trust: 2,
+      children: [
+        { hash: 'c1a', depth: 2, trust: 1, children: [] },
+        { hash: 'c1b', depth: 2, trust: 1, children: [] },
+      ],
+    },
+    {
+      hash: 'c2',
+      depth: 1,
+      trust: 4,
+      children: [
+        { hash: 'c2a', depth: 2, trust: 3, children: [] },
+        { hash: 'c2b', depth: 2, trust: 2, children: [] },
+      ],
+    },
+  ],
+};
+
+const score = calcResonanceScore(tree);
+assert.equal(score, 36);
+console.log('✅ RetrnScoreEngine test passed');


### PR DESCRIPTION
## Summary
- implement `RetrnScoreEngine` for scoring Retrn trees
- add placeholder contract loader and trust score utility
- include RetrnIndex ABI
- add simple unit test with a mocked tree

## Testing
- `npx --prefix ado-core ts-node test/RetrnScoreEngine.test.ts` *(fails: Unknown file extension ".ts")*


------
https://chatgpt.com/codex/tasks/task_e_6856e88dbfb08333a0181fd0dad97627