### PR TITLE
Add single-command Merkle sync script

### DIFF
--- a/indexer/emitAndPost.ts
+++ b/indexer/emitAndPost.ts
@@ -1,0 +1,14 @@
+import { emitMerkleDrop } from "./emitDailyMerkle";
+import { postMerkleRoot } from "./postMerkleRoot";
+
+async function run() {
+  const today = new Date().toISOString().split("T")[0];
+  console.log(`🚀 Emitting + Posting Merkle Drop for ${today}...`);
+
+  await emitMerkleDrop();
+  await postMerkleRoot(today);
+
+  console.log("✅ Drop complete and published.");
+}
+
+run();

--- a/indexer/emitDailyMerkle.ts
+++ b/indexer/emitDailyMerkle.ts
@@ -35,7 +35,7 @@ async function calculateRewards() {
   return rewards;
 }
 
-async function emitMerkleDrop() {
+export async function emitMerkleDrop() {
   const rewards = await calculateRewards();
 
   const entries = Object.entries(rewards).map(([addr, amount]) => ({
@@ -55,4 +55,4 @@ async function emitMerkleDrop() {
   );
 }
 
-emitMerkleDrop();
+

--- a/indexer/postMerkleRoot.ts
+++ b/indexer/postMerkleRoot.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import MerkleDropABI from "./abis/MerkleDropDistributor.json";
 import { loadContract } from "./contract";
 
-async function postMerkleRoot(date: string) {
+export async function postMerkleRoot(date: string) {
   const path = `./output/merkle-${date}.json`;
   const json = JSON.parse(fs.readFileSync(path, "utf-8"));
 
@@ -18,5 +18,4 @@ async function postMerkleRoot(date: string) {
   console.log(`✅ Merkle root for ${date} posted to chain:\n  ${merkleRoot}`);
 }
 
-const today = new Date().toISOString().split("T")[0];
-postMerkleRoot(today);
+


### PR DESCRIPTION
## Summary
- create `emitAndPost.ts` for one-shot Merkle sync
- export `emitMerkleDrop` and `postMerkleRoot` functions

## Testing
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Unknown file extension)*
- `npx ts-node indexer/emitAndPost.ts` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_6856f7b062448333a900063a33b74d03