### PR TITLE
Add PostEarnings component

### DIFF
--- a/thisrightnow/src/components/PostEarnings.tsx
+++ b/thisrightnow/src/components/PostEarnings.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { getPostEarnings } from "@/utils/fetchPostEarnings";
+
+export default function PostEarnings({ postHash }: { postHash: string }) {
+  const [earnings, setEarnings] = useState<any>(null);
+
+  useEffect(() => {
+    getPostEarnings(postHash).then(setEarnings);
+  }, [postHash]);
+
+  if (!earnings) return null;
+
+  return (
+    <div className="p-3 bg-yellow-50 rounded border mb-4">
+      <h3 className="font-semibold text-sm mb-2">💸 Post Earnings</h3>
+      <ul className="text-sm text-gray-800">
+        <li>👁️ Views: {earnings.views} TRN</li>
+        <li>🔁 Retrns: {earnings.retrns} TRN</li>
+        <li>🔥 Blessings: {earnings.blessings} TRN</li>
+        <li>🧠 Resonance Bonus: {earnings.resonance} TRN</li>
+        <li>🏦 Vault Bonus: {earnings.vault || 0} TRN</li>
+        <li className="font-bold mt-2">Total: {earnings.total} TRN</li>
+      </ul>
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/post/[hash].tsx
+++ b/thisrightnow/src/pages/post/[hash].tsx
@@ -1,0 +1,21 @@
+import { useRouter } from "next/router";
+import PostEarnings from "@/components/PostEarnings";
+
+export default function PostPage() {
+  const router = useRouter();
+  const { hash } = router.query;
+
+  if (!hash || typeof hash !== "string") return <p>Loading...</p>;
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Post {hash}</h1>
+      {/* Post content would go here */}
+      <PostEarnings postHash={hash as string} />
+      <div className="mt-4">
+        <h2 className="font-semibold">🔁 Retrns</h2>
+        {/* retrns list placeholder */}
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/utils/fetchPostEarnings.ts
+++ b/thisrightnow/src/utils/fetchPostEarnings.ts
@@ -1,0 +1,11 @@
+export async function getPostEarnings(postHash: string): Promise<any> {
+  // Replace with actual fetch later
+  return {
+    views: 3,
+    retrns: 4,
+    blessings: 2,
+    resonance: 5,
+    vault: 1,
+    total: 15,
+  };
+}


### PR DESCRIPTION
## Summary
- show TRN earnings for posts
- stub out `fetchPostEarnings`
- create post details page displaying earnings

## Testing
- `npx hardhat test` *(fails: Trying to use a non-local installation of Hardhat)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685700487030833381532d6936af7c3a