### PR TITLE
Implement post earnings API

### DIFF
--- a/indexer/abis/BlessBurnTracker.json
+++ b/indexer/abis/BlessBurnTracker.json
@@ -1,0 +1,28 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "blessPost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "burnPost",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/indexer/postEarnings.ts
+++ b/indexer/postEarnings.ts
@@ -1,0 +1,33 @@
+import ViewIndexABI from "./abis/ViewIndex.json";
+import RetrnIndexABI from "./abis/RetrnIndex.json";
+import BlessBurnABI from "./abis/BlessBurnTracker.json";
+import { loadContract } from "./contract";
+import { getRetrnDepth } from "./retrnWalker";
+
+export async function getPostEarningsFromChain(postHash: string) {
+  const views = await getViewCount(postHash);
+  const retrns = await getRetrnDepth(postHash);
+  const blessScore = await getBlessScore(postHash);
+  const resonance = Math.floor(retrns * blessScore * 0.1);
+
+  return {
+    views,
+    retrns,
+    blessings: blessScore,
+    resonance,
+    vault: 0,
+    total: views + retrns + blessScore + resonance,
+  };
+}
+
+async function getViewCount(hash: string) {
+  const contract = await loadContract("ViewIndex", ViewIndexABI);
+  const result = await contract.viewCount(hash);
+  return Number(result);
+}
+
+async function getBlessScore(hash: string) {
+  const contract = await loadContract("BlessBurnTracker", BlessBurnABI);
+  const result = await contract.score(hash);
+  return Number(result);
+}

--- a/indexer/retrnWalker.ts
+++ b/indexer/retrnWalker.ts
@@ -1,0 +1,8 @@
+import RetrnIndexABI from "./abis/RetrnIndex.json";
+import { loadContract } from "./contract";
+
+export async function getRetrnDepth(postHash: string): Promise<number> {
+  const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+  const retrns = await contract.getRetrns(postHash);
+  return retrns.length;
+}

--- a/indexer/server.ts
+++ b/indexer/server.ts
@@ -1,0 +1,11 @@
+import express from "express";
+import { getPostEarningsFromChain } from "./postEarnings";
+
+const app = express();
+app.get("/api/earnings/post/:hash", async (req, res) => {
+  const hash = req.params.hash;
+  const earnings = await getPostEarningsFromChain(hash);
+  res.json(earnings);
+});
+
+app.listen(4000, () => console.log("\ud83d\dd0c Earnings API at http://localhost:4000"));

--- a/thisrightnow/src/utils/fetchPostEarnings.ts
+++ b/thisrightnow/src/utils/fetchPostEarnings.ts
@@ -1,11 +1,4 @@
 export async function getPostEarnings(postHash: string): Promise<any> {
-  // Replace with actual fetch later
-  return {
-    views: 3,
-    retrns: 4,
-    blessings: 2,
-    resonance: 5,
-    vault: 1,
-    total: 15,
-  };
+  const res = await fetch(`http://localhost:4000/api/earnings/post/${postHash}`);
+  return await res.json();
 }


### PR DESCRIPTION
## Summary
- add BlessBurnTracker ABI to indexer
- implement `getPostEarningsFromChain` helper
- add `retrnWalker` utility
- expose earnings via an express server
- fetch earnings data from the frontend

## Testing
- `npm test` in `ado-core`
- `TS_NODE_COMPILER_OPTIONS='{"module":"commonjs","moduleResolution":"node","resolveJsonModule":true,"esModuleInterop":true}' npx -y ts-node --transpile-only test/RetrnScoreEngine.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857027024c88333935f42bc710b858b