### PR TITLE
Fix ts-node test execution

### DIFF
--- a/indexer/contract.ts
+++ b/indexer/contract.ts
@@ -1,6 +1,5 @@
-import { ethers } from "ethers";
-
-export async function loadContract(name: string, abi: ethers.InterfaceAbi) {
+export async function loadContract(name: string, abi: any) {
+  const { ethers } = await import("ethers");
   const provider = new ethers.JsonRpcProvider(
     process.env.RPC_URL || "http://localhost:8545"
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
## Summary
- load `ethers` dynamically to avoid missing dependency on startup
- add root `tsconfig.json` with common ts-node options

## Testing
- `npx -y ts-node --transpile-only test/RetrnScoreEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6857487ac3f8833387e7b06f9a33462d