### PR TITLE
Add DAO payouts dashboard

### DIFF
--- a/indexer/payoutSummary.ts
+++ b/indexer/payoutSummary.ts
@@ -1,0 +1,16 @@
+export function getPayoutSummary() {
+  // Replace with actual logic from on-chain + indexer
+  return {
+    totalRevenue: 10000,
+    lastSplitDate: "2025-06-18",
+    breakdown: {
+      "Investor Vaults": 3300,
+      "Contributor Vaults": 2000,
+      "Country NFTs": 1000,
+      "Stability Pool": 700,
+      "Merkle Drops": 1500,
+      "AI/Boost Rewards": 800,
+      "Burned TRN": 700,
+    },
+  };
+}

--- a/indexer/server.ts
+++ b/indexer/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { getPostEarningsFromChain } from "./postEarnings";
 import { getUserEarnings } from "./userEarnings";
+import { getPayoutSummary } from "./payoutSummary";
 
 const app = express();
 app.get("/api/earnings/post/:hash", async (req, res) => {
@@ -17,6 +18,10 @@ app.get("/api/earnings/user/:addr", async (req, res) => {
   } catch (e) {
     res.status(500).json({ error: "Failed to get user earnings" });
   }
+});
+
+app.get("/api/payouts", (req, res) => {
+  res.json(getPayoutSummary());
 });
 
 app.listen(4000, () => console.log("\ud83d\dd0c Earnings API at http://localhost:4000"));

--- a/thisrightnow/src/pages/payouts.tsx
+++ b/thisrightnow/src/pages/payouts.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+export default function PayoutsDashboard() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    fetch("http://localhost:4000/api/payouts")
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  if (!data) return <p className="p-4">Loading DAO payout summary...</p>;
+
+  const { totalRevenue, breakdown, lastSplitDate } = data;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-4">🏛️ DAO Payout Dashboard</h1>
+
+      <div className="bg-gray-100 p-4 rounded mb-6">
+        <p className="text-lg font-semibold">Total Revenue</p>
+        <p className="text-2xl">{totalRevenue.toFixed(2)} TRN</p>
+        <p className="text-xs text-gray-600">Last split: {lastSplitDate}</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        {Object.entries(breakdown).map(([label, value]) => (
+          <div key={label} className="bg-white shadow p-4 rounded border">
+            <p className="text-sm text-gray-600">{label}</p>
+            <p className="text-xl font-semibold">{(value as number).toFixed(2)} TRN</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 text-sm">
+        <p className="text-gray-500">Links:</p>
+        <ul className="list-disc list-inside">
+          <li><a className="text-blue-600 underline" href="/vaults">Vault Split Flow</a></li>
+          <li><a className="text-blue-600 underline" href="/merkle-preview">Merkle Drop</a></li>
+          <li><a className="text-blue-600 underline" href="/analytics">Top Earners</a></li>
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/payouts` page for the front‑end
- add mocked payout summary service on the indexer
- expose new `/api/payouts` endpoint from the API server

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6857498bab048333a4976cd86db4b4ad