### PR TITLE
Add IPFS upload utils and tagged post forms

### DIFF
--- a/thisrightnow/src/abi/RetrnIndex.json
+++ b/thisrightnow/src/abi/RetrnIndex.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrns",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/CreatePost.tsx
+++ b/thisrightnow/src/components/CreatePost.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { submitPost } from "@/utils/submitPost";
+
+export default function CreatePost() {
+  const [text, setText] = useState("");
+  const [tags, setTags] = useState("");
+
+  const handleSubmit = async () => {
+    if (!text || text.length < 3) {
+      alert("Post too short.");
+      return;
+    }
+    if (text.length > 1024) {
+      alert("Post too long.");
+      return;
+    }
+
+    const tagArr = tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    try {
+      await submitPost(text, tagArr);
+      setText("");
+      setTags("");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to submit post.");
+    }
+  };
+
+  return (
+    <div className="border p-4 mb-4">
+      <textarea
+        className="w-full border p-2"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Write something..."
+      />
+      <input
+        type="text"
+        className="w-full border p-2 mt-2"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        placeholder="Tags: ai, memes, politics"
+      />
+      <button onClick={handleSubmit} className="mt-2">
+        Submit
+      </button>
+    </div>
+  );
+}

--- a/thisrightnow/src/components/CreateRetrn.tsx
+++ b/thisrightnow/src/components/CreateRetrn.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { submitRetrn } from "@/utils/submitRetrn";
+
+export default function CreateRetrn({ parentHash }: { parentHash: string }) {
+  const [text, setText] = useState("");
+  const [tags, setTags] = useState("");
+
+  const handleSubmit = async () => {
+    if (!text || text.length < 3) {
+      alert("Post too short.");
+      return;
+    }
+    if (text.length > 1024) {
+      alert("Post too long.");
+      return;
+    }
+
+    const tagArr = tags
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+    try {
+      await submitRetrn(parentHash, text, tagArr);
+      setText("");
+      setTags("");
+    } catch (err) {
+      console.error(err);
+      alert("Failed to submit retrn.");
+    }
+  };
+
+  return (
+    <div className="border p-4 mb-4">
+      <textarea
+        className="w-full border p-2"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Write something..."
+      />
+      <input
+        type="text"
+        className="w-full border p-2 mt-2"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        placeholder="Tags: ai, memes, politics"
+      />
+      <button onClick={handleSubmit} className="mt-2">
+        Submit Retrn
+      </button>
+    </div>
+  );
+}

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ethers } from 'ethers';
 import ViewIndexABI from '../abi/ViewIndex.json';
 import BlessBurnTrackerABI from '../abi/BlessBurnTracker.json';
+import CreateRetrn from './CreateRetrn';
 
 interface Post {
   hash: string;
@@ -71,6 +72,7 @@ export default function PostCard({ post, user }: { post: Post; user: string }) {
         <button disabled={blessed} onClick={handleBless}>🙏 Bless</button>
         <button disabled={burned} onClick={handleBurn}>🔥 Burn</button>
       </div>
+      <CreateRetrn parentHash={post.hash} />
     </div>
   );
 }

--- a/thisrightnow/src/pages/index.tsx
+++ b/thisrightnow/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import { useAccount } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import PostCard from '../components/PostCard';
+import CreatePost from '../components/CreatePost';
 import mockPosts from '../../public/mockPosts.json';
 
 export default function Home() {
@@ -10,6 +11,9 @@ export default function Home() {
     <div className="p-4">
       <h1>ThisRightNow</h1>
       <ConnectButton />
+      <div className="mt-4">
+        <CreatePost />
+      </div>
       <div className="mt-6">
         {mockPosts.map((post) => (
           <PostCard key={post.hash} post={post} user={address ?? ''} />

--- a/thisrightnow/src/utils/submitPost.ts
+++ b/thisrightnow/src/utils/submitPost.ts
@@ -1,0 +1,16 @@
+import ViewIndexABI from "@/abi/ViewIndex.json";
+import { loadContract } from "./contract";
+import { uploadToIPFS } from "./uploadToIPFS";
+
+export async function submitPost(content: string, tags: string[] = []) {
+  const ipfsHash = await uploadToIPFS({
+    content,
+    tags,
+    timestamp: Date.now(),
+  });
+
+  const contract = await loadContract("ViewIndex", ViewIndexABI);
+  await (contract as any).registerView(ipfsHash);
+
+  return ipfsHash;
+}

--- a/thisrightnow/src/utils/submitRetrn.ts
+++ b/thisrightnow/src/utils/submitRetrn.ts
@@ -1,0 +1,17 @@
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import { loadContract } from "./contract";
+import { uploadToIPFS } from "./uploadToIPFS";
+
+export async function submitRetrn(originalHash: string, content: string, tags: string[] = []) {
+  const ipfsHash = await uploadToIPFS({
+    content,
+    parent: originalHash,
+    tags,
+    timestamp: Date.now(),
+  });
+
+  const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+  await (contract as any).registerRetrn(ipfsHash, originalHash);
+
+  return ipfsHash;
+}

--- a/thisrightnow/src/utils/uploadToIPFS.ts
+++ b/thisrightnow/src/utils/uploadToIPFS.ts
@@ -1,0 +1,9 @@
+import { NFTStorage } from "nft.storage";
+
+const client = new NFTStorage({ token: process.env.NFT_STORAGE_KEY! });
+
+export async function uploadToIPFS(post: any): Promise<string> {
+  const blob = new Blob([JSON.stringify(post)], { type: "application/json" });
+  const cid = await client.storeBlob(blob);
+  return `ipfs://${cid}`;
+}


### PR DESCRIPTION
## Summary
- enable uploading post data to IPFS via nft.storage
- add `submitPost` and `submitRetrn` helpers
- allow tagging when creating posts or retrns
- create simple post and retrn forms
- integrate creation form in home page

## Testing
- `npm run lint` in `thisrightnow`
- `npm test` *(fails: could not find package.json)*
- `npm test` in `ado-core` *(fails: requires interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_68574a828d248333bd9017481cbe525a