### PR TITLE
Add IPFS post fetching

### DIFF
--- a/thisrightnow/public/mockPosts.json
+++ b/thisrightnow/public/mockPosts.json
@@ -1,4 +1,4 @@
 [
-  { "hash": "0xabc123", "title": "First Post", "content": "This is your first signal." },
-  { "hash": "0xdef456", "title": "Second Post", "content": "This one has a retrn coming." }
+  { "ipfsHash": "ipfs://bafkreighfakehash1" },
+  { "ipfsHash": "ipfs://bafkreighfakehash2" }
 ]

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -1,78 +1,21 @@
-import { useState } from 'react';
-import { ethers } from 'ethers';
-import ViewIndexABI from '../abi/ViewIndex.json';
-import BlessBurnTrackerABI from '../abi/BlessBurnTracker.json';
-import CreateRetrn from './CreateRetrn';
+import { useEffect, useState } from "react";
+import { fetchPost } from "@/utils/fetchPost";
 
-interface Post {
-  hash: string;
-  title: string;
-  content: string;
-}
+export default function PostCard({ ipfsHash }: { ipfsHash: string }) {
+  const [post, setPost] = useState<any>(null);
 
-const VIEW_INDEX_ADDR = '0xYourViewIndexAddress';
-const BLESS_BURN_ADDR = '0xYourBlessBurnAddress';
+  useEffect(() => {
+    fetchPost(ipfsHash).then(setPost).catch(console.error);
+  }, [ipfsHash]);
 
-export default function PostCard({ post, user }: { post: Post; user: string }) {
-  const [viewed, setViewed] = useState(false);
-  const [blessed, setBlessed] = useState(false);
-  const [burned, setBurned] = useState(false);
-
-  const handleView = async () => {
-    if (!user || viewed) return;
-    try {
-      const provider = new ethers.BrowserProvider(
-        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
-      );
-      const signer = await provider.getSigner();
-      const contract = new ethers.Contract(VIEW_INDEX_ADDR, ViewIndexABI, signer);
-      await contract.logView(post.hash);
-      setViewed(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  const handleBless = async () => {
-    if (!user || blessed) return;
-    try {
-      const provider = new ethers.BrowserProvider(
-        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
-      );
-      const signer = await provider.getSigner();
-      const contract = new ethers.Contract(BLESS_BURN_ADDR, BlessBurnTrackerABI, signer);
-      await contract.blessPost(post.hash);
-      setBlessed(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  const handleBurn = async () => {
-    if (!user || burned) return;
-    try {
-      const provider = new ethers.BrowserProvider(
-        (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
-      );
-      const signer = await provider.getSigner();
-      const contract = new ethers.Contract(BLESS_BURN_ADDR, BlessBurnTrackerABI, signer);
-      await contract.burnPost(post.hash);
-      setBurned(true);
-    } catch (err) {
-      console.error(err);
-    }
-  };
+  if (!post) return <div className="p-4 bg-gray-100">Loading post...</div>;
 
   return (
-    <div className="border p-4 mb-4">
-      <h2>{post.title}</h2>
+    <div className="p-4 bg-white shadow rounded my-2">
       <p>{post.content}</p>
-      <div className="mt-2">
-        <button disabled={viewed} onClick={handleView}>👁️ View</button>
-        <button disabled={blessed} onClick={handleBless}>🙏 Bless</button>
-        <button disabled={burned} onClick={handleBurn}>🔥 Burn</button>
+      <div className="text-xs text-gray-500 mt-2">
+        {post.tags?.join(", ")} · {new Date(post.timestamp).toLocaleString()}
       </div>
-      <CreateRetrn parentHash={post.hash} />
     </div>
   );
 }

--- a/thisrightnow/src/pages/index.tsx
+++ b/thisrightnow/src/pages/index.tsx
@@ -1,11 +1,9 @@
-import { useAccount } from 'wagmi';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import PostCard from '../components/PostCard';
 import CreatePost from '../components/CreatePost';
 import mockPosts from '../../public/mockPosts.json';
 
 export default function Home() {
-  const { address } = useAccount();
 
   return (
     <div className="p-4">
@@ -16,7 +14,7 @@ export default function Home() {
       </div>
       <div className="mt-6">
         {mockPosts.map((post) => (
-          <PostCard key={post.hash} post={post} user={address ?? ''} />
+          <PostCard key={post.ipfsHash} ipfsHash={post.ipfsHash} />
         ))}
       </div>
     </div>

--- a/thisrightnow/src/utils/fetchPost.ts
+++ b/thisrightnow/src/utils/fetchPost.ts
@@ -1,0 +1,6 @@
+export async function fetchPost(cidOrUri: string) {
+  const cid = cidOrUri.replace("ipfs://", "");
+  const res = await fetch(`http://localhost:8080/ipfs/${cid}`);
+  if (!res.ok) throw new Error("Failed to fetch IPFS content");
+  return await res.json();
+}


### PR DESCRIPTION
## Summary
- fetch posts from a local IPFS gateway
- render posts with new PostCard component
- list mock post hashes and fetch them

## Testing
- `npx hardhat test` *(fails: needs packages)*
- `npm run lint` in `thisrightnow` *(fails: cannot find ESLint plugin)*
- `node test/RetrnScoreEngine.test.ts` *(fails: unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_68574cf0df488333b84be027a6e1a06a