### PR TITLE
Fix logging function names

### DIFF
--- a/thisrightnow/src/utils/submitPost.ts
+++ b/thisrightnow/src/utils/submitPost.ts
@@ -10,7 +10,7 @@ export async function submitPost(content: string, tags: string[] = []) {
   });
 
   const contract = await loadContract("ViewIndex", ViewIndexABI);
-  await (contract as any).registerView(ipfsHash);
+  await (contract as any).logView(ipfsHash);
 
   return ipfsHash;
 }

--- a/thisrightnow/src/utils/submitRetrn.ts
+++ b/thisrightnow/src/utils/submitRetrn.ts
@@ -11,7 +11,7 @@ export async function submitRetrn(originalHash: string, content: string, tags: s
   });
 
   const contract = await loadContract("RetrnIndex", RetrnIndexABI);
-  await (contract as any).registerRetrn(ipfsHash, originalHash);
+  await (contract as any).logRetrn(ipfsHash, originalHash);
 
   return ipfsHash;
 }


### PR DESCRIPTION
## Summary
- use `logView` instead of `registerView` when submitting posts
- call `logRetrn` for retrn submissions

## Testing
- `npm test` in `ado-core`
- `npm run lint` in `thisrightnow`
- `npm run build` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_685752a5a35c8333958504edc371d39a