### PR TITLE
Add frontend path alias

### DIFF
--- a/thisrightnow/tsconfig.app.json
+++ b/thisrightnow/tsconfig.app.json
@@ -14,6 +14,10 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/thisrightnow/vite.config.ts
+++ b/thisrightnow/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- alias `@` to `src` in Vite config
- support the same alias in TypeScript config

## Testing
- `npm test` in `ado-core`
- `npm run lint` in `thisrightnow`
- `npx -y ts-node test/RetrnScoreEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_685752a8e4108333a9276718711981f7