### PR TITLE
Remove conflicting JS hardhat config

### DIFF
--- a/ado-core/hardhat.config.js
+++ b/ado-core/hardhat.config.js
@@ -1,6 +1,0 @@
-require("@nomicfoundation/hardhat-toolbox");
-
-/** @type import('hardhat/config').HardhatUserConfig */
-module.exports = {
-  solidity: "0.8.28",
-};


### PR DESCRIPTION
## Summary
- remove `ado-core/hardhat.config.js` so only the TypeScript config is used

## Testing
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_685752a9969c8333bda1b01b9b9bdef2