### PR TITLE
Add recursive retrn tree page

### DIFF
--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -1,20 +1,29 @@
 import { useEffect, useState } from "react";
 import { fetchPost } from "@/utils/fetchPost";
 
-export default function PostCard({ ipfsHash }: { ipfsHash: string }) {
-  const [post, setPost] = useState<any>(null);
+export default function PostCard({
+  ipfsHash,
+  post,
+}: {
+  ipfsHash: string;
+  post?: any;
+}) {
+  const [data, setData] = useState(post || null);
 
   useEffect(() => {
-    fetchPost(ipfsHash).then(setPost).catch(console.error);
-  }, [ipfsHash]);
+    if (!post) {
+      fetchPost(ipfsHash).then(setData).catch(console.error);
+    }
+  }, [ipfsHash, post]);
 
-  if (!post) return <div className="p-4 bg-gray-100">Loading post...</div>;
+  if (!data)
+    return <div className="p-2 bg-gray-100">Loading...</div>;
 
   return (
-    <div className="p-4 bg-white shadow rounded my-2">
-      <p>{post.content}</p>
+    <div className="bg-white border rounded p-3 shadow-sm">
+      <p>{data.content}</p>
       <div className="text-xs text-gray-500 mt-2">
-        {post.tags?.join(", ")} · {new Date(post.timestamp).toLocaleString()}
+        {data.tags?.join(", ")} · {new Date(data.timestamp).toLocaleString()}
       </div>
     </div>
   );

--- a/thisrightnow/src/pages/branch/[hash].tsx
+++ b/thisrightnow/src/pages/branch/[hash].tsx
@@ -1,12 +1,15 @@
 import { useRouter } from "next/router";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { fetchPost } from "@/utils/fetchPost";
 import { loadContract } from "@/utils/contract";
 import RetrnIndexABI from "@/abi/RetrnIndex.json";
 import PostCard from "@/components/PostCard";
 
+const RETRN_INDEX = "0xYourContractAddressHere";
+
 async function fetchRetrns(parent: string) {
-  const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+  const contract = await loadContract(RETRN_INDEX, RetrnIndexABI);
   const hashes: string[] = await (contract as any).getRetrns(parent);
   const data = await Promise.all(
     hashes.map(async (h) => {
@@ -31,6 +34,12 @@ function RecursiveRetrnTree({ parentHash }: { parentHash: string }) {
       {children.map((child) => (
         <div key={child.hash}>
           <PostCard ipfsHash={child.hash} post={child} />
+          <Link
+            href={`/branch/${child.hash}`}
+            className="text-sm text-blue-600 underline mt-1 inline-block"
+          >
+            View branch →
+          </Link>
           <RecursiveRetrnTree parentHash={child.hash} />
         </div>
       ))}

--- a/thisrightnow/src/pages/branch/[hash].tsx
+++ b/thisrightnow/src/pages/branch/[hash].tsx
@@ -1,0 +1,62 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { fetchPost } from "@/utils/fetchPost";
+import { loadContract } from "@/utils/contract";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import PostCard from "@/components/PostCard";
+
+async function fetchRetrns(parent: string) {
+  const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+  const hashes: string[] = await (contract as any).getRetrns(parent);
+  const data = await Promise.all(
+    hashes.map(async (h) => {
+      const d = await fetchPost(h);
+      return { ...d, hash: h };
+    })
+  );
+  return data;
+}
+
+function RecursiveRetrnTree({ parentHash }: { parentHash: string }) {
+  const [children, setChildren] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchRetrns(parentHash).then(setChildren).catch(console.error);
+  }, [parentHash]);
+
+  if (!children.length) return null;
+
+  return (
+    <div className="mt-4 space-y-4 pl-4 border-l-2 border-green-400">
+      {children.map((child) => (
+        <div key={child.hash}>
+          <PostCard ipfsHash={child.hash} post={child} />
+          <RecursiveRetrnTree parentHash={child.hash} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function BranchPage() {
+  const router = useRouter();
+  const { hash } = router.query;
+  const [rootPost, setRootPost] = useState<any>(null);
+
+  useEffect(() => {
+    if (!hash || typeof hash !== "string") return;
+    fetchPost(hash as string)
+      .then((p) => setRootPost({ ...p, hash }))
+      .catch(console.error);
+  }, [hash]);
+
+  if (!hash || typeof hash !== "string") return <p>Loading...</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">🌳 Retrn Thread</h1>
+      {rootPost && <PostCard ipfsHash={rootPost.hash} post={rootPost} />}
+      {hash && <RecursiveRetrnTree parentHash={hash as string} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add recursive retrn branch page under `pages/branch/[hash].tsx`
- extend `PostCard` to accept preloaded post data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685754df4cd88333a9a6ef923bb92da3