### PR TITLE
Enable threaded replies

### DIFF
--- a/thisrightnow/src/components/CreateRetrn.tsx
+++ b/thisrightnow/src/components/CreateRetrn.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { submitRetrn } from "@/utils/submitRetrn";
 
-export default function CreateRetrn({ parentHash }: { parentHash: string }) {
+export default function CreateRetrn({
+  parentHash,
+  onRetrn,
+}: {
+  parentHash: string;
+  onRetrn?: (data: any) => void;
+}) {
   const [text, setText] = useState("");
   const [tags, setTags] = useState("");
 
@@ -21,9 +27,18 @@ export default function CreateRetrn({ parentHash }: { parentHash: string }) {
       .filter(Boolean);
 
     try {
-      await submitRetrn(parentHash, text, tagArr);
+      const hash = await submitRetrn(parentHash, text, tagArr);
       setText("");
       setTags("");
+      if (onRetrn) {
+        const data = {
+          content: text,
+          tags: tagArr,
+          timestamp: Date.now(),
+          hash,
+        };
+        onRetrn(data);
+      }
     } catch (err) {
       console.error(err);
       alert("Failed to submit retrn.");

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -1,30 +1,63 @@
 import { useEffect, useState } from "react";
 import { fetchPost } from "@/utils/fetchPost";
+import { loadContract } from "@/utils/contract";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import CreateRetrn from "./CreateRetrn";
 
 export default function PostCard({
   ipfsHash,
   post,
+  showReplies = false,
 }: {
   ipfsHash: string;
   post?: any;
+  showReplies?: boolean;
 }) {
   const [data, setData] = useState(post || null);
+  const [retrns, setRetrns] = useState<any[]>([]);
 
   useEffect(() => {
-    if (!post) {
-      fetchPost(ipfsHash).then(setData).catch(console.error);
-    }
+    if (!post) fetchPost(ipfsHash).then(setData).catch(console.error);
   }, [ipfsHash, post]);
 
-  if (!data)
-    return <div className="p-2 bg-gray-100">Loading...</div>;
+  useEffect(() => {
+    if (!showReplies || !ipfsHash) return;
+    const loadRetrns = async () => {
+      const contract = await loadContract("RetrnIndex", RetrnIndexABI);
+      const hashes = await (contract as any).getRetrns(ipfsHash);
+      const results = await Promise.all(
+        hashes.map(async (h: string) => {
+          const d = await fetchPost(h);
+          return { ...d, hash: h };
+        })
+      );
+      setRetrns(results);
+    };
+    loadRetrns();
+  }, [showReplies, ipfsHash]);
+
+  if (!data) return <div className="p-2 bg-gray-100">Loading...</div>;
 
   return (
-    <div className="bg-white border rounded p-3 shadow-sm">
+    <div className="bg-white border rounded p-4 shadow-sm">
       <p>{data.content}</p>
       <div className="text-xs text-gray-500 mt-2">
         {data.tags?.join(", ")} · {new Date(data.timestamp).toLocaleString()}
       </div>
+
+      {showReplies && (
+        <>
+          <CreateRetrn
+            parentHash={ipfsHash}
+            onRetrn={(r) => setRetrns([r, ...retrns])}
+          />
+          <div className="ml-4 mt-4 border-l-2 pl-4 space-y-3">
+            {retrns.map((r, i) => (
+              <PostCard key={r.hash} ipfsHash={r.hash} post={r} showReplies={false} />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/thisrightnow/src/pages/branch/[hash].tsx
+++ b/thisrightnow/src/pages/branch/[hash].tsx
@@ -64,7 +64,9 @@ export default function BranchPage() {
   return (
     <div className="max-w-2xl mx-auto p-6">
       <h1 className="text-2xl font-bold mb-4">🌳 Retrn Thread</h1>
-      {rootPost && <PostCard ipfsHash={rootPost.hash} post={rootPost} />}
+      {rootPost && (
+        <PostCard ipfsHash={rootPost.hash} post={rootPost} showReplies={true} />
+      )}
       {hash && <RecursiveRetrnTree parentHash={hash as string} />}
     </div>
   );


### PR DESCRIPTION
## Summary
- add `CreateRetrn` callback handler
- render replies in `PostCard`
- allow replies on branch page

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` in ado-core *(fails: tries to install hardhat interactively)*

------
https://chatgpt.com/codex/tasks/task_e_6857591ba4048333b4b08b0e778768c6