### PR TITLE
Log retrn views

### DIFF
--- a/thisrightnow/src/utils/submitRetrn.ts
+++ b/thisrightnow/src/utils/submitRetrn.ts
@@ -1,4 +1,5 @@
 import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import ViewIndexABI from "@/abi/ViewIndex.json";
 import { loadContract } from "./contract";
 import { uploadToIPFS } from "./uploadToIPFS";
 
@@ -12,6 +13,10 @@ export async function submitRetrn(originalHash: string, content: string, tags: s
 
   const contract = await loadContract("RetrnIndex", RetrnIndexABI);
   await (contract as any).logRetrn(ipfsHash, originalHash);
+
+  // Also record this retrn in the view index so it can earn TRN
+  const viewIndex = await loadContract("ViewIndex", ViewIndexABI);
+  await (viewIndex as any).logView(ipfsHash);
 
   return ipfsHash;
 }


### PR DESCRIPTION
## Summary
- track retrn views in `submitRetrn`

## Testing
- `npx hardhat test` *(fails: Trying to use a non-local installation of Hardhat)*
- `npx ts-node ../test/RetrnScoreEngine.test.ts` *(fails: Needs ts-node install)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857628f977883338b659fb8d827a892