### PR TITLE
Implement post registration in ViewIndex

### DIFF
--- a/ado-core/test/ViewIndex.test.ts
+++ b/ado-core/test/ViewIndex.test.ts
@@ -2,15 +2,41 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 describe("ViewIndex", function () {
-  it("should log a view", async function () {
-    const [user] = await ethers.getSigners();
+  it("should register a new post", async function () {
+    const [author] = await ethers.getSigners();
     const ViewIndex = await ethers.getContractFactory("ViewIndex");
     const viewIndex = await ViewIndex.deploy();
-    await viewIndex.logView(ethers.encodeBytes32String("post123"));
-    const hasViewed = await viewIndex.hasUserViewed(
-      ethers.encodeBytes32String("post123"),
-      user.address
+    const hash = ethers.encodeBytes32String("post123");
+
+    await viewIndex.connect(author).registerPost(hash);
+    const meta = await viewIndex.getPostMeta(hash);
+    expect(meta[0]).to.equal(author.address);
+    expect(meta[1]).to.be.gt(0);
+    expect(meta[2]).to.equal(0);
+  });
+
+  it("should increment view count", async function () {
+    const [author, viewer] = await ethers.getSigners();
+    const ViewIndex = await ethers.getContractFactory("ViewIndex");
+    const viewIndex = await ViewIndex.deploy();
+    const hash = ethers.encodeBytes32String("post123");
+
+    await viewIndex.connect(author).registerPost(hash);
+    await viewIndex.connect(viewer).registerView(hash);
+
+    const meta = await viewIndex.getPostMeta(hash);
+    expect(meta[2]).to.equal(1);
+  });
+
+  it("should revert when registering twice", async function () {
+    const [author] = await ethers.getSigners();
+    const ViewIndex = await ethers.getContractFactory("ViewIndex");
+    const viewIndex = await ViewIndex.deploy();
+    const hash = ethers.encodeBytes32String("post123");
+
+    await viewIndex.connect(author).registerPost(hash);
+    await expect(viewIndex.connect(author).registerPost(hash)).to.be.revertedWith(
+      "Already registered"
     );
-    expect(hasViewed).to.equal(true);
   });
 });

--- a/indexer/abis/ViewIndex.json
+++ b/indexer/abis/ViewIndex.json
@@ -2,61 +2,49 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "viewer",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "postHash",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "timestamp",
-        "type": "uint256"
-      }
+      { "indexed": true, "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "author", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" }
+    ],
+    "name": "PostRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "viewer", "type": "address" }
     ],
     "name": "ViewLogged",
     "type": "event"
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "postHash",
-        "type": "bytes32"
-      }
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
     ],
-    "name": "logView",
+    "name": "registerPost",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "postHash",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "viewer",
-        "type": "address"
-      }
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
     ],
-    "name": "hasUserViewed",
+    "name": "registerView",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
+    ],
+    "name": "getPostMeta",
     "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
     ],
     "stateMutability": "view",
     "type": "function"

--- a/indexer/viewIndexer.ts
+++ b/indexer/viewIndexer.ts
@@ -10,18 +10,25 @@ const views: {
   [day: string]: { postHash: string; viewer: string; timestamp: number }[];
 } = {};
 
-contract.on("ViewLogged", (viewer: string, postHash: string, timestamp: ethers.BigNumberish) => {
-  const day = new Date(Number(timestamp) * 1000).toISOString().split("T")[0];
+contract.on(
+  "ViewLogged",
+  async (postHash: string, viewer: string, event: ethers.EventLog) => {
+    const block = await event.getBlock();
+    const timestamp = block.timestamp;
+    const day = new Date(Number(timestamp) * 1000)
+      .toISOString()
+      .split("T")[0];
 
-  if (!views[day]) views[day] = [];
-  views[day].push({
-    postHash,
-    viewer,
-    timestamp: Number(timestamp),
-  });
+    if (!views[day]) views[day] = [];
+    views[day].push({
+      postHash,
+      viewer,
+      timestamp: Number(timestamp),
+    });
 
-  console.log(`[${day}] View recorded for post ${postHash} by ${viewer}`);
-});
+    console.log(`[${day}] View recorded for post ${postHash} by ${viewer}`);
+  }
+);
 
 // Optionally dump raw + deduped view data
 setInterval(() => {

--- a/thisrightnow/src/abi/ViewIndex.json
+++ b/thisrightnow/src/abi/ViewIndex.json
@@ -1,15 +1,52 @@
 [
   {
+    "anonymous": false,
     "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "postHash",
-        "type": "bytes32"
-      }
+      { "indexed": true, "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "author", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" }
     ],
-    "name": "logView",
+    "name": "PostRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "viewer", "type": "address" }
+    ],
+    "name": "ViewLogged",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
+    ],
+    "name": "registerPost",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
+    ],
+    "name": "registerView",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" }
+    ],
+    "name": "getPostMeta",
+    "outputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -52,7 +52,7 @@ export default function PostCard({
             onRetrn={(r) => setRetrns([r, ...retrns])}
           />
           <div className="ml-4 mt-4 border-l-2 pl-4 space-y-3">
-            {retrns.map((r, i) => (
+            {retrns.map((r) => (
               <PostCard key={r.hash} ipfsHash={r.hash} post={r} showReplies={false} />
             ))}
           </div>

--- a/thisrightnow/src/utils/submitPost.ts
+++ b/thisrightnow/src/utils/submitPost.ts
@@ -10,7 +10,7 @@ export async function submitPost(content: string, tags: string[] = []) {
   });
 
   const contract = await loadContract("ViewIndex", ViewIndexABI);
-  await (contract as any).logView(ipfsHash);
+  await (contract as any).registerPost(ipfsHash);
 
   return ipfsHash;
 }

--- a/thisrightnow/src/utils/submitRetrn.ts
+++ b/thisrightnow/src/utils/submitRetrn.ts
@@ -16,7 +16,7 @@ export async function submitRetrn(originalHash: string, content: string, tags: s
 
   // Also record this retrn in the view index so it can earn TRN
   const viewIndex = await loadContract("ViewIndex", ViewIndexABI);
-  await (viewIndex as any).logView(ipfsHash);
+  await (viewIndex as any).registerPost(ipfsHash);
 
   return ipfsHash;
 }


### PR DESCRIPTION
## Summary
- add `registerPost` and `registerView` to `ViewIndex`
- update frontend helpers to use the new function
- update ABI files for the new interface
- adjust view indexer script for new event shape
- fix lint error in `PostCard`
- add tests for post registration logic

## Testing
- `npx hardhat test`
- `NODE_OPTIONS=--experimental-vm-modules npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68576f44614883339ba1e92f85ff4d17