### PR TITLE
Add BoostingModule test and token

### DIFF
--- a/ado-core/contracts/BoostingModule.sol
+++ b/ado-core/contracts/BoostingModule.sol
@@ -1,32 +1,52 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-/// @title BoostingModule
-/// @notice Allows users to boost their own posts for increased visibility and TRN payouts to viewers.
-/// @dev All boosts are self-initiated. Boost ends early if the post is burned.
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+interface ITRNUsageOracle {
+    function reportSpend(address user, uint256 amount, string calldata action) external;
+    function reportEarning(address user, uint256 amount, bytes32 sourceHash) external;
+    function reportTransfer(address from, address to, uint256 amount) external;
+}
+
+/// @title BoostingModule
+/// @notice Allows creators to fund boosts for their posts. Viewers earn TRN from the allocated budget.
 contract BoostingModule {
     event BoostStarted(address indexed booster, bytes32 indexed postHash, uint256 trnAmount, uint256 timestamp);
     event BoostEnded(bytes32 indexed postHash, address indexed booster, uint256 timestamp);
 
     struct Boost {
         address booster;
-        uint256 amount;
+        uint256 amount;       // total funded
+        uint256 remaining;    // unspent amount
         uint256 startTime;
         bool active;
     }
 
-    mapping(bytes32 => Boost) public boosts;
+    IERC20 public token;
+    ITRNUsageOracle public oracle;
 
-    /// @notice Starts a boost campaign. Only the original post creator may call this.
+    mapping(bytes32 => Boost) public boosts;
+    mapping(bytes32 => mapping(address => uint256)) public viewerEarnings;
+    mapping(address => uint256) public refunds;
+
+    constructor(address _token, address _oracle) {
+        token = IERC20(_token);
+        oracle = ITRNUsageOracle(_oracle);
+    }
+
+    /// @notice Starts a boost campaign. Only the post creator should call this in production.
     function startBoost(bytes32 postHash, uint256 trnAmount) external {
-        require(boosts[postHash].active == false, "Already boosted");
+        require(!boosts[postHash].active, "Already boosted");
         require(trnAmount > 0, "TRN required");
 
-        // Placeholder check: In real logic, verify sender is post creator
+        token.transferFrom(msg.sender, address(this), trnAmount);
+        oracle.reportSpend(msg.sender, trnAmount, "boost");
+
         boosts[postHash] = Boost({
             booster: msg.sender,
             amount: trnAmount,
+            remaining: trnAmount,
             startTime: block.timestamp,
             active: true
         });
@@ -34,16 +54,45 @@ contract BoostingModule {
         emit BoostStarted(msg.sender, postHash, trnAmount, block.timestamp);
     }
 
-    /// @notice Ends a boost campaign early (e.g. on post burn). Returns unused TRN in final implementation.
-    function endBoost(bytes32 postHash) external {
+    /// @notice Registers a view of a boosted post and allocates earnings to the viewer.
+    function registerBoostView(bytes32 postHash) external {
         Boost storage boost = boosts[postHash];
+        require(boost.active, "Not active");
+        require(boost.remaining > 0, "No funds");
+
+        uint256 reward = 1e18;
+        if (reward > boost.remaining) {
+            reward = boost.remaining;
+        }
+
+        boost.remaining -= reward;
+        viewerEarnings[postHash][msg.sender] += reward;
+        oracle.reportEarning(msg.sender, reward, postHash);
+    }
+
+    function claimable(bytes32 postHash, address viewer) external view returns (uint256) {
+        return viewerEarnings[postHash][viewer];
+    }
+
+    /// @notice Ends a boost early (e.g. when a post is burned) and refunds the remaining TRN.
+    function burnPost(bytes32 postHash) external {
+        Boost storage boost = boosts[postHash];
+        require(msg.sender == boost.booster, "Not booster");
         require(boost.active, "Not active");
 
         boost.active = false;
+        uint256 remaining = boost.remaining;
+        boost.remaining = 0;
+
+        if (remaining > 0) {
+            refunds[boost.booster] += remaining;
+            token.transfer(boost.booster, remaining);
+            oracle.reportEarning(boost.booster, remaining, keccak256("boost-refund"));
+        }
+
         emit BoostEnded(postHash, boost.booster, block.timestamp);
     }
 
-    /// @notice Returns boost info for a post
     function getBoost(bytes32 postHash) external view returns (Boost memory) {
         return boosts[postHash];
     }

--- a/ado-core/contracts/MockTRN.sol
+++ b/ado-core/contracts/MockTRN.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockTRN
+/// @notice Simple ERC20 token used for testing TRN flows.
+contract MockTRN is ERC20 {
+    constructor() ERC20("Turncoin", "TRN") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/ado-core/test/BoostingFlow.test.ts
+++ b/ado-core/test/BoostingFlow.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("Boosting Flow", function () {
+  let usageOracle: any;
+  let boosting: any;
+  let token: any;
+  let user: any;
+  let viewer: any;
+  let postHash: string;
+
+  beforeEach(async () => {
+    const signers = await ethers.getSigners();
+    user = signers[0];
+    viewer = signers[1];
+
+    const Token = await ethers.getContractFactory("MockTRN");
+    token = await Token.deploy();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    usageOracle = await Oracle.deploy();
+
+    const Boosting = await ethers.getContractFactory("BoostingModule");
+    boosting = await Boosting.deploy(token.target, usageOracle.target);
+
+    postHash = ethers.encodeBytes32String("post-abc");
+    await token.mint(user.address, ethers.parseEther("100"));
+    await token.connect(user).approve(boosting.target, ethers.parseEther("100"));
+  });
+
+  it("should allow a user to boost a post", async () => {
+    await boosting.connect(user).startBoost(postHash, ethers.parseEther("10"));
+    const info = await boosting.boosts(postHash);
+    expect(info.amount).to.equal(ethers.parseEther("10"));
+  });
+
+  it("should register views and accumulate earnings for viewers", async () => {
+    await boosting.connect(user).startBoost(postHash, ethers.parseEther("30"));
+
+    await boosting.connect(viewer).registerBoostView(postHash);
+    await boosting.connect(viewer).registerBoostView(postHash);
+
+    const claimable = await boosting.claimable(postHash, viewer.address);
+    expect(claimable).to.be.gt(0);
+  });
+
+  it("should allow refund of unspent boost funds if post is burned", async () => {
+    await boosting.connect(user).startBoost(postHash, ethers.parseEther("20"));
+
+    await boosting.connect(user).burnPost(postHash); // Ends boost early
+
+    const refund = await boosting.refunds(user.address);
+    expect(refund).to.equal(ethers.parseEther("20"));
+  });
+});


### PR DESCRIPTION
## Summary
- add `MockTRN` ERC20 for testing
- expand `BoostingModule` with token/usageOracle interactions
- implement refund logic for burned posts
- test boosting flow with Hardhat

## Testing
- `npm install --silent` in `ado-core`
- `npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6857716477a08333b177c2dd7e582bd4