### PR TITLE
Add boost TRN balance check

### DIFF
--- a/thisrightnow/src/pages/boost.tsx
+++ b/thisrightnow/src/pages/boost.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
-import { ethers } from "ethers";
+import { useState, useEffect } from "react";
+import { ethers, formatEther, parseEther } from "ethers";
 import { loadContract } from "@/utils/contract";
 import BoostingModuleABI from "@/abi/BoostingModule.json";
+import { getOracleBalance } from "@/utils/oracle";
 import { useAccount } from "wagmi";
 
 export default function BoostPage() {
@@ -9,6 +10,14 @@ export default function BoostPage() {
   const [postHash, setPostHash] = useState("");
   const [amount, setAmount] = useState("5");
   const [status, setStatus] = useState("");
+  const [oracleTRN, setOracleTRN] = useState("0");
+
+  useEffect(() => {
+    if (!address) return;
+    getOracleBalance(address).then(setOracleTRN);
+  }, [address]);
+
+  const canBoost = parseEther(amount || "0") <= BigInt(oracleTRN);
 
   const handleBoost = async () => {
     setStatus("Sending transaction...");
@@ -47,23 +56,30 @@ export default function BoostPage() {
           />
         </div>
 
-        <div>
-          <label className="block font-semibold mb-1">Amount (TRN)</label>
-          <input
-            type="number"
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            className="w-full p-2 border rounded"
-          />
-        </div>
+          <div>
+            <label className="block font-semibold mb-1">Amount (TRN)</label>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              className="w-full p-2 border rounded"
+            />
+            <p className="text-sm text-gray-600">
+              Available TRN via Oracle: {formatEther(oracleTRN)}
+            </p>
+          </div>
 
-        <button
-          onClick={handleBoost}
-          disabled={!address}
-          className="bg-purple-600 text-white px-6 py-2 rounded"
-        >
-          Start Boost
-        </button>
+          <button
+            onClick={handleBoost}
+            disabled={!address || !canBoost}
+            className={`px-6 py-2 rounded ${
+              canBoost
+                ? "bg-purple-600 text-white"
+                : "bg-gray-400 text-gray-100 cursor-not-allowed"
+            }`}
+          >
+            Start Boost
+          </button>
 
         {status && <p className="mt-3 text-sm text-gray-700">{status}</p>}
       </div>

--- a/thisrightnow/src/utils/oracle.ts
+++ b/thisrightnow/src/utils/oracle.ts
@@ -1,0 +1,8 @@
+import OracleABI from "@/abi/TRNUsageOracle.json";
+import { loadContract } from "./contract";
+
+export async function getOracleBalance(addr: string): Promise<string> {
+  const contract = await loadContract("TRNUsageOracle", OracleABI);
+  const balance = await (contract as any).getAvailableTRN(addr);
+  return balance.toString();
+}


### PR DESCRIPTION
## Summary
- add `getOracleBalance` helper to check available TRN in the TRNUsageOracle
- show user's oracle balance on the boost page
- disable boost button when balance is insufficient

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685774529b508333ad7a1c8649b0d0a0