### PR TITLE
Add Top Earners page

### DIFF
--- a/thisrightnow/src/pages/top.tsx
+++ b/thisrightnow/src/pages/top.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { fetchTopEarners, fetchTopPosts } from "@/utils/topData";
+import Link from "next/link";
+
+export default function TopPage() {
+  const [users, setUsers] = useState<any[]>([]);
+  const [posts, setPosts] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchTopEarners().then(setUsers);
+    fetchTopPosts().then(setPosts);
+  }, []);
+
+  return (
+    <div className="max-w-3xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-6">🏆 Top Earners</h1>
+
+      <div className="mb-10">
+        <h2 className="text-xl font-semibold mb-2">🧑‍🚀 Users</h2>
+        <ul className="space-y-2">
+          {users.map((u, i) => (
+            <li key={u.address} className="p-3 bg-white rounded shadow">
+              #{i + 1} – <Link href={`/account/${u.address}`} className="text-blue-600">{u.address}</Link>
+              <span className="float-right font-bold">{u.trn} TRN</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-2">📝 Posts</h2>
+        <ul className="space-y-2">
+          {posts.map((p, i) => (
+            <li key={p.hash} className="p-3 bg-white rounded shadow">
+              #{i + 1} – <Link href={`/post/${p.hash}`} className="text-blue-600">{p.preview}</Link>
+              <span className="float-right font-bold">{p.trn} TRN</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/utils/topData.ts
+++ b/thisrightnow/src/utils/topData.ts
@@ -1,0 +1,15 @@
+export async function fetchTopEarners() {
+  return [
+    { address: "0xabc...def", trn: 192.3 },
+    { address: "0x123...456", trn: 130.0 },
+    { address: "0x999...888", trn: 99.7 },
+  ];
+}
+
+export async function fetchTopPosts() {
+  return [
+    { hash: "QmPost1", preview: "🔥 Ethereum won't survive unless...", trn: 75.2 },
+    { hash: "QmPost2", preview: "📉 The future of AI is...", trn: 58.7 },
+    { hash: "QmPost3", preview: "😱 This DAO changed my life", trn: 44.1 },
+  ];
+}


### PR DESCRIPTION
## Summary
- add `/top` route in frontend
- include temporary mock data helpers

## Testing
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68577753e5708333a137ddab32d82197