### PR TITLE
Improve TRN claim UX

### DIFF
--- a/thisrightnow/src/components/EarningsBreakdown.tsx
+++ b/thisrightnow/src/components/EarningsBreakdown.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { formatEther, parseEther } from "ethers";
 
 export default function EarningsBreakdown({ address }: { address: string }) {
   const [data, setData] = useState<any>(null);
@@ -12,6 +13,11 @@ export default function EarningsBreakdown({ address }: { address: string }) {
 
   if (!data) return <p className="text-gray-500">Loading earnings...</p>;
 
+  const merkleClaimable = parseEther(String(data.merkleTRN || 0));
+  const investorClaimable = parseEther(String(data.vaults.investor || 0));
+  const contributorClaimable = parseEther(String(data.vaults.contributor || 0));
+  const total = merkleClaimable + investorClaimable + contributorClaimable;
+
   return (
     <div className="mt-4 space-y-4">
       <div className="bg-gray-100 p-4 rounded">
@@ -20,6 +26,21 @@ export default function EarningsBreakdown({ address }: { address: string }) {
         <p>🏦 Investor Vault: {data.vaults.investor} TRN</p>
         <p>🧑‍💻 Contributor Vault: {data.vaults.contributor} TRN</p>
         <p>🌳 Merkle Drop: {data.merkleTRN} TRN</p>
+        <div className="space-y-3 mt-4">
+          <p>
+            <strong>Merkle Airdrops:</strong> {formatEther(merkleClaimable)} TRN
+          </p>
+          <p>
+            <strong>Investor Vault:</strong> {formatEther(investorClaimable)} TRN
+          </p>
+          <p>
+            <strong>Contributor Vault:</strong> {formatEther(contributorClaimable)} TRN
+          </p>
+          <p>
+            <strong>Total Claimable:</strong>{" "}
+            <span className="text-green-600">{formatEther(total)} TRN</span>
+          </p>
+        </div>
       </div>
 
       <div className="bg-gray-100 p-4 rounded">

--- a/thisrightnow/src/pages/dashboard.tsx
+++ b/thisrightnow/src/pages/dashboard.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { claimMerkle, claimVaults } from "@/utils/claim";
+
+export default function Dashboard() {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const handleClaimAll = async () => {
+    setStatus("Processing...");
+    try {
+      await claimMerkle();
+      await claimVaults();
+      setStatus("✅ All claims successful!");
+    } catch (e) {
+      setStatus("❌ Claim failed. Try again.");
+    }
+    setTimeout(() => setStatus(null), 5000);
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Claim Dashboard</h1>
+      <button
+        className="bg-purple-600 text-white px-4 py-2 rounded"
+        onClick={handleClaimAll}
+      >
+        Claim All
+      </button>
+      {status && <p className="mt-4 text-center text-sm">{status}</p>}
+    </div>
+  );
+}

--- a/thisrightnow/src/utils/claim.ts
+++ b/thisrightnow/src/utils/claim.ts
@@ -1,0 +1,7 @@
+export async function claimMerkle() {
+  await new Promise((res) => setTimeout(res, 500));
+}
+
+export async function claimVaults() {
+  await new Promise((res) => setTimeout(res, 500));
+}


### PR DESCRIPTION
## Summary
- enhance earnings breakdown with a clear claimable section
- add dashboard page with claim status feedback
- include helper utilities for simulated claims

## Testing
- `cd ado-core && npm test`
- `cd ../test && npx -y ts-node RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_68577aea6e388333a9a50a51706e388e