### PR TITLE
Add claim history table

### DIFF
--- a/thisrightnow/src/components/ClaimHistory.tsx
+++ b/thisrightnow/src/components/ClaimHistory.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+
+type Claim = {
+  type: "merkle" | "investor" | "contributor";
+  amount: string;
+  timestamp: number;
+  tx: string;
+};
+
+export default function ClaimHistory({ address }: { address: string }) {
+  const [claims, setClaims] = useState<Claim[]>([]);
+
+  useEffect(() => {
+    // Mock data — replace with real fetch from indexer or subgraph later
+    setClaims([
+      {
+        type: "merkle",
+        amount: "42.69",
+        timestamp: Date.now() - 86_400_000 * 1,
+        tx: "0xabc123...",
+      },
+      {
+        type: "investor",
+        amount: "88.01",
+        timestamp: Date.now() - 86_400_000 * 2,
+        tx: "0xdef456...",
+      },
+    ]);
+  }, [address]);
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-semibold mb-2">🧾 Claim History</h2>
+
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 border">Source</th>
+            <th className="p-2 border">Amount (TRN)</th>
+            <th className="p-2 border">Date</th>
+            <th className="p-2 border">Tx</th>
+          </tr>
+        </thead>
+        <tbody>
+          {claims.map((c, i) => (
+            <tr key={i} className="text-center">
+              <td className="p-2 border capitalize">{c.type}</td>
+              <td className="p-2 border font-mono">{c.amount}</td>
+              <td className="p-2 border">
+                {new Date(c.timestamp).toLocaleDateString()}
+              </td>
+              <td className="p-2 border">
+                <a
+                  href={`https://explorer.zora.energy/tx/${c.tx}`}
+                  className="text-blue-600"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  View
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {claims.length === 0 && (
+        <p className="mt-4 text-center text-gray-500">No claims yet.</p>
+      )}
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/account/[addr].tsx
+++ b/thisrightnow/src/pages/account/[addr].tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import merkle from "@/data/merkle-2025-06-18.json";
 import { readTRNEarnings } from "@/utils/readOracle";
 import EarningsBreakdown from "@/components/EarningsBreakdown";
+import ClaimHistory from "@/components/ClaimHistory";
 
 export default function AccountPage() {
   const router = useRouter();
@@ -67,6 +68,7 @@ export default function AccountPage() {
       </div>
 
       <EarningsBreakdown address={addr as string} />
+      <ClaimHistory address={addr as string} />
     </div>
   );
 }

--- a/thisrightnow/src/pages/dashboard.tsx
+++ b/thisrightnow/src/pages/dashboard.tsx
@@ -10,7 +10,7 @@ export default function Dashboard() {
       await claimMerkle();
       await claimVaults();
       setStatus("✅ All claims successful!");
-    } catch (e) {
+    } catch {
       setStatus("❌ Claim failed. Try again.");
     }
     setTimeout(() => setStatus(null), 5000);


### PR DESCRIPTION
## Summary
- show claim history on account page
- add ClaimHistory component
- fix lint on dashboard page

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'next/router' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68577c4056a88333bc4ef439d717112f