### PR TITLE
Add claim event logging and history fetch

### DIFF
--- a/ado-core/contracts/MockContributorVault.sol
+++ b/ado-core/contracts/MockContributorVault.sol
@@ -8,6 +8,8 @@ interface ITRNUsageOracle {
 contract MockContributorVault {
     mapping(address => uint256) public claimable;
 
+    event Claimed(address indexed user, uint256 amount);
+
     function mockDistribute(address user, uint256 amount) external {
         claimable[user] += amount;
     }
@@ -16,6 +18,7 @@ contract MockContributorVault {
         uint256 amount = claimable[msg.sender];
         require(amount > 0, "Nothing to claim");
         claimable[msg.sender] = 0;
+        emit Claimed(msg.sender, amount);
         ITRNUsageOracle(oracle).reportEarning(msg.sender, amount, keccak256("contributor-vault"));
     }
 }

--- a/ado-core/contracts/MockInvestorVault.sol
+++ b/ado-core/contracts/MockInvestorVault.sol
@@ -8,6 +8,8 @@ interface ITRNUsageOracle {
 contract MockInvestorVault {
     mapping(address => uint256) public claimable;
 
+    event Claimed(address indexed user, uint256 amount);
+
     function mockDistribute(address user, uint256 amount) external {
         claimable[user] += amount;
     }
@@ -16,6 +18,7 @@ contract MockInvestorVault {
         uint256 amount = claimable[msg.sender];
         require(amount > 0, "Nothing to claim");
         claimable[msg.sender] = 0;
+        emit Claimed(msg.sender, amount);
         ITRNUsageOracle(oracle).reportEarning(msg.sender, amount, keccak256("investor-vault"));
     }
 }

--- a/thisrightnow/src/abi/MockContributorVault.json
+++ b/thisrightnow/src/abi/MockContributorVault.json
@@ -1,0 +1,18 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "inputs": [ { "internalType": "address", "name": "oracle", "type": "address" } ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/abi/MockInvestorVault.json
+++ b/thisrightnow/src/abi/MockInvestorVault.json
@@ -1,0 +1,18 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "inputs": [ { "internalType": "address", "name": "oracle", "type": "address" } ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/ClaimHistory.tsx
+++ b/thisrightnow/src/components/ClaimHistory.tsx
@@ -1,31 +1,14 @@
 import { useEffect, useState } from "react";
+import { getClaimEvents, ClaimEvent } from "@/utils/getClaimEvents";
 
-type Claim = {
-  type: "merkle" | "investor" | "contributor";
-  amount: string;
-  timestamp: number;
-  tx: string;
-};
+type Claim = ClaimEvent;
 
 export default function ClaimHistory({ address }: { address: string }) {
   const [claims, setClaims] = useState<Claim[]>([]);
 
   useEffect(() => {
-    // Mock data — replace with real fetch from indexer or subgraph later
-    setClaims([
-      {
-        type: "merkle",
-        amount: "42.69",
-        timestamp: Date.now() - 86_400_000 * 1,
-        tx: "0xabc123...",
-      },
-      {
-        type: "investor",
-        amount: "88.01",
-        timestamp: Date.now() - 86_400_000 * 2,
-        tx: "0xdef456...",
-      },
-    ]);
+    if (!address) return;
+    getClaimEvents(address).then(setClaims);
   }, [address]);
 
   return (

--- a/thisrightnow/src/utils/getClaimEvents.ts
+++ b/thisrightnow/src/utils/getClaimEvents.ts
@@ -1,0 +1,56 @@
+import { ethers } from "ethers";
+import { loadContract } from "./contract";
+import MerkleABI from "@/abi/MerkleDropDistributor.json";
+import InvestorABI from "@/abi/MockInvestorVault.json";
+import ContributorABI from "@/abi/MockContributorVault.json";
+import { formatEther } from "viem";
+
+export type ClaimEvent = {
+  type: "merkle" | "investor" | "contributor";
+  amount: string;
+  timestamp: number;
+  tx: string;
+};
+
+export async function getClaimEvents(address: string): Promise<ClaimEvent[]> {
+  const provider = new ethers.BrowserProvider(
+    (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+  );
+
+  const merkle = await loadContract("MerkleDropDistributor", MerkleABI);
+  const investor = await loadContract("MockInvestorVault", InvestorABI);
+  const contributor = await loadContract("MockContributorVault", ContributorABI);
+
+  const filterUser = (e: any) =>
+    e.args.user.toLowerCase() === address.toLowerCase();
+
+  const [merkleLogs, investorLogs, contributorLogs] = await Promise.all([
+    merkle.queryFilter("Claimed"),
+    investor.queryFilter("Claimed"),
+    contributor.queryFilter("Claimed"),
+  ]);
+
+  const parse = async (logs: any[], type: ClaimEvent["type"]) => {
+    return Promise.all(
+      logs
+        .filter(filterUser)
+        .map(async (e: any) => {
+          const block = await provider.getBlock(e.blockNumber);
+          return {
+            type,
+            amount: formatEther(e.args.amount),
+            timestamp: Number(block.timestamp) * 1000,
+            tx: e.transactionHash,
+          } as ClaimEvent;
+        })
+    );
+  };
+
+  const results = [
+    ...(await parse(merkleLogs, "merkle")),
+    ...(await parse(investorLogs, "investor")),
+    ...(await parse(contributorLogs, "contributor")),
+  ];
+
+  return results.sort((a, b) => b.timestamp - a.timestamp);
+}


### PR DESCRIPTION
## Summary
- emit `Claimed` events from the mock vault contracts
- create ABIs for the vault contracts for the frontend
- add helper to fetch claim events from contracts
- display real claim history in the Account page

## Testing
- `npm install` in `ado-core`
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm install` in `thisrightnow`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68577da280908333991b2ba97fc8f93f