### PR TITLE
Add earnings breakdown and explorer links

### DIFF
--- a/thisrightnow/src/components/ClaimHistory.tsx
+++ b/thisrightnow/src/components/ClaimHistory.tsx
@@ -1,14 +1,21 @@
 import { useEffect, useState } from "react";
 import { getClaimEvents, ClaimEvent } from "@/utils/getClaimEvents";
+import { getEarningsBreakdown } from "@/utils/getEarningsBreakdown";
 
 type Claim = ClaimEvent;
 
 export default function ClaimHistory({ address }: { address: string }) {
   const [claims, setClaims] = useState<Claim[]>([]);
+  const [earnings, setEarnings] = useState({
+    views: "0",
+    retrns: "0",
+    boosts: "0",
+  });
 
   useEffect(() => {
     if (!address) return;
     getClaimEvents(address).then(setClaims);
+    getEarningsBreakdown(address).then(setEarnings);
   }, [address]);
 
   return (
@@ -35,9 +42,9 @@ export default function ClaimHistory({ address }: { address: string }) {
               <td className="p-2 border">
                 <a
                   href={`https://explorer.zora.energy/tx/${c.tx}`}
-                  className="text-blue-600"
                   target="_blank"
                   rel="noreferrer"
+                  className="text-blue-600 hover:underline"
                 >
                   View
                 </a>
@@ -50,6 +57,15 @@ export default function ClaimHistory({ address }: { address: string }) {
       {claims.length === 0 && (
         <p className="mt-4 text-center text-gray-500">No claims yet.</p>
       )}
+
+      <div className="mt-8">
+        <h2 className="text-lg font-semibold mb-2">📊 Earnings Breakdown</h2>
+        <ul className="text-sm space-y-1">
+          <li>📺 From Views: {earnings.views} TRN</li>
+          <li>🔁 From Retrns: {earnings.retrns} TRN</li>
+          <li>🚀 From Boosts: {earnings.boosts} TRN</li>
+        </ul>
+      </div>
     </div>
   );
 }

--- a/thisrightnow/src/utils/getClaimEvents.ts
+++ b/thisrightnow/src/utils/getClaimEvents.ts
@@ -31,18 +31,16 @@ export async function getClaimEvents(address: string): Promise<ClaimEvent[]> {
   ]);
 
   const parse = async (logs: any[], type: ClaimEvent["type"]) => {
-    return Promise.all(
-      logs
-        .filter(filterUser)
-        .map(async (e: any) => {
-          const block = await provider.getBlock(e.blockNumber);
-          return {
-            type,
-            amount: formatEther(e.args.amount),
-            timestamp: Number(block.timestamp) * 1000,
-            tx: e.transactionHash,
-          } as ClaimEvent;
-        })
+    return await Promise.all(
+      logs.filter(filterUser).map(async (e: any) => {
+        const block = await provider.getBlock(e.blockNumber);
+        return {
+          type,
+          amount: formatEther(e.args.amount),
+          timestamp: (block.timestamp as number) * 1000,
+          tx: e.transactionHash,
+        } as ClaimEvent;
+      })
     );
   };
 

--- a/thisrightnow/src/utils/getEarningsBreakdown.ts
+++ b/thisrightnow/src/utils/getEarningsBreakdown.ts
@@ -1,0 +1,8 @@
+export async function getEarningsBreakdown(address: string) {
+  // Stub: replace with actual contract reads or off-chain indexer call
+  return {
+    views: "17.420",
+    retrns: "22.360",
+    boosts: "14.000",
+  };
+}


### PR DESCRIPTION
## Summary
- add earnings breakdown stub utility
- show link to explorer with hover style in ClaimHistory
- fetch and display earnings breakdown for account
- parse claim block timestamps correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857803c462c83338c7cd5a9201c431f