### PR TITLE
Implement user earnings API route

### DIFF
--- a/pages/api/earnings/user/[addr].ts
+++ b/pages/api/earnings/user/[addr].ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// Mock earnings — replace with real indexer data later
+const mockEarnings: Record<string, { totals: { views: string; retrns: string; boosts: string }; byPost: { hash: string; views: string; retrns: string; boosts: string }[] }> = {
+  "0x123": {
+    totals: {
+      views: "12.34",
+      retrns: "5.67",
+      boosts: "3.21",
+    },
+    byPost: [
+      {
+        hash: "QmPost1...",
+        views: "3.00",
+        retrns: "1.00",
+        boosts: "0.00",
+      },
+      {
+        hash: "QmPost2...",
+        views: "9.34",
+        retrns: "4.67",
+        boosts: "3.21",
+      },
+    ],
+  },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { addr } = req.query;
+  const lowerAddr = (addr as string).toLowerCase();
+
+  const earnings = mockEarnings[lowerAddr];
+
+  if (!earnings) {
+    return res.status(404).json({ error: "No earnings found" });
+  }
+
+  return res.status(200).json({
+    address: addr,
+    ...earnings,
+  });
+}


### PR DESCRIPTION
## Summary
- add serverless route at `pages/api/earnings/user/[addr].ts`

## Testing
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm test` in `ado-core` *(fails: needs hardhat install)*

------
https://chatgpt.com/codex/tasks/task_e_6857807b047c8333bc594592420452e5