### PR TITLE
Add per-post earnings

### DIFF
--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -2,23 +2,32 @@ import { useEffect, useState } from "react";
 import { fetchPost } from "@/utils/fetchPost";
 import { loadContract } from "@/utils/contract";
 import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import { getPostEarnings } from "@/utils/getPostEarnings";
 import CreateRetrn from "./CreateRetrn";
 
 export default function PostCard({
   ipfsHash,
   post,
   showReplies = false,
+  viewerAddr,
 }: {
   ipfsHash: string;
   post?: any;
   showReplies?: boolean;
+  viewerAddr?: string;
 }) {
   const [data, setData] = useState(post || null);
   const [retrns, setRetrns] = useState<any[]>([]);
+  const [earnings, setEarnings] = useState<number | null>(null);
 
   useEffect(() => {
     if (!post) fetchPost(ipfsHash).then(setData).catch(console.error);
   }, [ipfsHash, post]);
+
+  useEffect(() => {
+    if (!viewerAddr) return;
+    getPostEarnings(ipfsHash, viewerAddr).then(setEarnings);
+  }, [ipfsHash, viewerAddr]);
 
   useEffect(() => {
     if (!showReplies || !ipfsHash) return;
@@ -45,6 +54,12 @@ export default function PostCard({
         {data.tags?.join(", ")} · {new Date(data.timestamp).toLocaleString()}
       </div>
 
+      {earnings !== null && (
+        <p className="text-green-600 text-sm mt-1">
+          💸 Earned You: {earnings.toFixed(2)} TRN
+        </p>
+      )}
+
       {showReplies && (
         <>
           <CreateRetrn
@@ -53,7 +68,13 @@ export default function PostCard({
           />
           <div className="ml-4 mt-4 border-l-2 pl-4 space-y-3">
             {retrns.map((r) => (
-              <PostCard key={r.hash} ipfsHash={r.hash} post={r} showReplies={false} />
+              <PostCard
+                key={r.hash}
+                ipfsHash={r.hash}
+                post={r}
+                showReplies={false}
+                viewerAddr={viewerAddr}
+              />
             ))}
           </div>
         </>

--- a/thisrightnow/src/pages/branch/[hash].tsx
+++ b/thisrightnow/src/pages/branch/[hash].tsx
@@ -1,11 +1,13 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 import { fetchPost } from "@/utils/fetchPost";
 import PostCard from "@/components/PostCard";
 import RecursiveRetrnTree from "@/components/RecursiveRetrnTree";
 
 export default function BranchPage() {
   const router = useRouter();
+  const { address: viewerAddr } = useAccount();
   const { hash } = router.query;
   const [rootPost, setRootPost] = useState<any>(null);
 
@@ -23,7 +25,12 @@ export default function BranchPage() {
       <h1 className="text-2xl font-bold mb-4">🌳 Retrn Thread</h1>
       {rootPost && (
         <>
-          <PostCard ipfsHash={rootPost.hash} post={rootPost} showReplies={true} />
+          <PostCard
+            ipfsHash={rootPost.hash}
+            post={rootPost}
+            showReplies={true}
+            viewerAddr={viewerAddr || ""}
+          />
           <RecursiveRetrnTree parentHash={rootPost.hash} />
         </>
       )}

--- a/thisrightnow/src/pages/feed.tsx
+++ b/thisrightnow/src/pages/feed.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
 import { loadContract } from "@/utils/contract";
 import ViewIndexABI from "@/abi/ViewIndex.json";
 import RetrnIndexABI from "@/abi/RetrnIndex.json";
@@ -8,6 +9,7 @@ import Link from "next/link";
 import FeedReply from "@/components/FeedReply";
 
 export default function FeedPage() {
+  const { address: viewerAddr } = useAccount();
   const [posts, setPosts] = useState<any[]>([]);
 
   useEffect(() => {
@@ -38,7 +40,12 @@ export default function FeedPage() {
       <div className="space-y-8">
         {posts.map((p) => (
           <div key={p.hash} className="bg-white rounded shadow p-4">
-            <PostCard ipfsHash={p.hash} post={p} showReplies={false} />
+            <PostCard
+              ipfsHash={p.hash}
+              post={p}
+              showReplies={false}
+              viewerAddr={viewerAddr || ""}
+            />
 
             <div className="ml-4 mt-2 text-sm text-gray-600">
               {p.retrns.length > 0 && (

--- a/thisrightnow/src/utils/getEarningsBreakdown.ts
+++ b/thisrightnow/src/utils/getEarningsBreakdown.ts
@@ -1,4 +1,4 @@
-export async function getEarningsBreakdown(address: string) {
+export async function getEarningsBreakdown() {
   // Stub: replace with actual contract reads or off-chain indexer call
   return {
     views: "17.420",

--- a/thisrightnow/src/utils/getPostEarnings.ts
+++ b/thisrightnow/src/utils/getPostEarnings.ts
@@ -1,0 +1,13 @@
+export async function getPostEarnings(postHash: string, address: string) {
+  const res = await fetch(`/api/earnings/user/${address}`);
+  if (!res.ok) return null;
+
+  const data = await res.json();
+  const match = data.byPost.find((p: any) => p.hash === postHash);
+
+  return match
+    ? parseFloat(match.views) +
+        parseFloat(match.retrns) +
+        parseFloat(match.boosts)
+    : 0;
+}


### PR DESCRIPTION
## Summary
- fetch post earnings by post and viewer
- show TRN earned for each post
- pass viewer address from feed and branch pages
- silence unused variable in stub

## Testing
- `npm run lint` in `thisrightnow`
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6857831299c883339481cda0baab947f