### PR TITLE
Add trending scoring utility and page

### DIFF
--- a/thisrightnow/src/pages/trending.tsx
+++ b/thisrightnow/src/pages/trending.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { useAccount } from "wagmi";
+import { loadContract } from "@/utils/contract";
+import ViewIndexABI from "@/abi/ViewIndex.json";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import BoostingModuleABI from "@/abi/BoostingModule.json";
+import { fetchPost } from "@/utils/fetchPost";
+import { calcTrendingScore } from "@/utils/calcTrendingScore";
+import PostCard from "@/components/PostCard";
+
+// Placeholder until resonance calculation is implemented
+async function getResonanceScore(hash: string): Promise<number> {
+  void hash;
+  return 0;
+}
+
+export default function TrendingPage() {
+  const { address: viewerAddr } = useAccount();
+  const [posts, setPosts] = useState<any[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const viewIndex = await loadContract("ViewIndex", ViewIndexABI);
+      const hashes: string[] = await (viewIndex as any).getRecentPosts();
+
+      const retrnIndex = await loadContract("RetrnIndex", RetrnIndexABI);
+      const boostModule = await loadContract(
+        "BoostingModule",
+        BoostingModuleABI as any
+      );
+
+      const postsWithScores = await Promise.all(
+        hashes.map(async (hash) => {
+          const post = await fetchPost(hash);
+          const retrns: string[] = await (retrnIndex as any).getRetrns(hash);
+          const boostTRN = await (boostModule as any).boostAmountFor(hash);
+          const resonance = await getResonanceScore(hash);
+
+          const score = calcTrendingScore({
+            retrns: retrns.length,
+            boostTRN: parseFloat(boostTRN),
+            resonance,
+            createdAt: post.timestamp,
+          });
+
+          return { ...post, hash, score };
+        })
+      );
+
+      postsWithScores.sort((a, b) => b.score - a.score);
+      setPosts(postsWithScores);
+    };
+
+    load();
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">🔥 Trending Posts</h1>
+      <div className="space-y-8">
+        {posts.map((post) => (
+          <div key={post.hash} className="bg-white rounded shadow p-4">
+            <PostCard
+              ipfsHash={post.hash}
+              post={post}
+              showReplies={false}
+              viewerAddr={viewerAddr || ""}
+            />
+            <p className="text-xs text-gray-500">
+              🔥 Trending Score: {post.score.toFixed(2)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/utils/calcTrendingScore.ts
+++ b/thisrightnow/src/utils/calcTrendingScore.ts
@@ -1,0 +1,18 @@
+export function calcTrendingScore({
+  retrns,
+  boostTRN,
+  resonance,
+  createdAt,
+}: {
+  retrns: number;
+  boostTRN: number;
+  resonance: number;
+  createdAt: number; // ms
+}): number {
+  const ageInHours = (Date.now() - createdAt) / 3600000;
+  const decay = Math.pow(1 + ageInHours, 1.25);
+
+  return (
+    (retrns * 1 + Math.log(boostTRN + 1) * 2 + resonance * 3) / decay
+  );
+}


### PR DESCRIPTION
## Summary
- add `calcTrendingScore` to compute trending rank
- create a new `/trending` page that lists posts sorted by score

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68578a679cb0833382ff38e1dfa81925