### PR TITLE
Implement trending leaderboard

### DIFF
--- a/thisrightnow/src/utils/getResonanceScore.ts
+++ b/thisrightnow/src/utils/getResonanceScore.ts
@@ -1,0 +1,3 @@
+export async function getResonanceScore(_hash: string): Promise<number> {
+  return Math.random() * 5;
+}


### PR DESCRIPTION
## Summary
- bring Trending page to life with resonance & boost data
- sort posts by a trending score
- show rank and trending score for each entry
- stub out `getResonanceScore` util

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx hardhat test` *(fails: Needed package hardhat@2.24.3 to install)*

------
https://chatgpt.com/codex/tasks/task_e_68578d270b2083339df85979d40f1310