### PR TITLE
Add static trending data and page

### DIFF
--- a/thisrightnow/public/trending.json
+++ b/thisrightnow/public/trending.json
@@ -1,0 +1,22 @@
+[
+  {
+    "hash": "ipfs://bafkreighfakehash1",
+    "content": "First trending post!",
+    "author": "0x123",
+    "timestamp": 1718928000,
+    "retrns": 5,
+    "boostTRN": 50,
+    "resonance": 4.5,
+    "score": 85.32
+  },
+  {
+    "hash": "ipfs://bafkreighfakehash2",
+    "content": "Second trending post!",
+    "author": "0xabc",
+    "timestamp": 1718931600,
+    "retrns": 3,
+    "boostTRN": 20,
+    "resonance": 3.2,
+    "score": 60.25
+  }
+]


### PR DESCRIPTION
## Summary
- simplify Trending page to load `/trending.json`
- add sample `trending.json` in public folder

## Testing
- `npx hardhat test` *(fails: required package install prompt)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: required package install prompt)*
- `npm run lint` in `thisrightnow` *(fails: missing eslint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685791e359c8833399968376db5f44b0