### PR TITLE
Add trending API endpoint

### DIFF
--- a/pages/api/trending.ts
+++ b/pages/api/trending.ts
@@ -1,0 +1,22 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import fs from "fs";
+import path from "path";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const filePath = path.join(process.cwd(), "thisrightnow", "public", "trending.json");
+
+    if (!fs.existsSync(filePath)) {
+      return res.status(404).json({ error: "Trending data not found." });
+    }
+
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const data = JSON.parse(raw);
+
+    res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate");
+    res.status(200).json(data);
+  } catch (err) {
+    console.error("Error loading trending:", err);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+}

--- a/thisrightnow/src/pages/trending.tsx
+++ b/thisrightnow/src/pages/trending.tsx
@@ -7,7 +7,7 @@ export default function TrendingPage() {
   const { address } = useAccount();
 
   useEffect(() => {
-    fetch("/trending.json")
+    fetch("/api/trending")
       .then((res) => res.json())
       .then(setPosts)
       .catch(console.error);


### PR DESCRIPTION
## Summary
- add API route to serve trending data
- update trending page to call the new endpoint

## Testing
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint` in `thisrightnow` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685793df16ec83338fda78d9f34b2ba4