### PR TITLE
Add useTrending hook and integrate trending page

### DIFF
--- a/thisrightnow/package-lock.json
+++ b/thisrightnow/package-lock.json
@@ -14,6 +14,7 @@
         "nft.storage": "^7.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "swr": "^2.3.3",
         "viem": "^2.31.3",
         "wagmi": "^2.15.6"
       },
@@ -5121,6 +5122,15 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/derive-valtio": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/derive-valtio/-/derive-valtio-0.1.0.tgz",
@@ -8982,6 +8992,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/thread-stream": {

--- a/thisrightnow/package.json
+++ b/thisrightnow/package.json
@@ -13,11 +13,12 @@
     "@rainbow-me/rainbowkit": "^2.2.8",
     "@tanstack/react-query": "^5.80.7",
     "ethers": "^6.14.4",
+    "nft.storage": "^7.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "swr": "^2.3.3",
     "viem": "^2.31.3",
-    "wagmi": "^2.15.6",
-    "nft.storage": "^7.2.0"
+    "wagmi": "^2.15.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/thisrightnow/src/pages/trending.tsx
+++ b/thisrightnow/src/pages/trending.tsx
@@ -1,24 +1,19 @@
-import { useEffect, useState } from "react";
 import PostCard from "@/components/PostCard";
 import { useAccount } from "wagmi";
+import { useTrending } from "@/utils/useTrending";
 
 export default function TrendingPage() {
-  const [posts, setPosts] = useState<any[]>([]);
   const { address } = useAccount();
+  const { posts, isLoading } = useTrending();
 
-  useEffect(() => {
-    fetch("/api/trending")
-      .then((res) => res.json())
-      .then(setPosts)
-      .catch(console.error);
-  }, []);
+  if (isLoading) return <div className="p-6">Loading…</div>;
 
   return (
     <div className="max-w-2xl mx-auto p-6">
       <h1 className="text-2xl font-bold mb-6">🔥 Trending Retrns</h1>
 
       <div className="space-y-6">
-        {posts.map((p, i) => (
+        {posts.map((p: any, i: number) => (
           <div key={p.hash} className="bg-white rounded shadow p-4">
             <div className="flex justify-between mb-1 text-xs text-gray-500">
               <span># {i + 1}</span>

--- a/thisrightnow/src/utils/useTrending.ts
+++ b/thisrightnow/src/utils/useTrending.ts
@@ -1,0 +1,17 @@
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export function useTrending(category?: string) {
+  const { data, error, isLoading } = useSWR(
+    category ? `/api/trending?category=${category}` : `/api/trending`,
+    fetcher,
+    { refreshInterval: 60000 }
+  );
+
+  return {
+    posts: data || [],
+    isLoading,
+    isError: !!error,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared `useTrending` hook using SWR
- use the hook on the trending page
- install the `swr` dependency

## Testing
- `npm run lint` *(fails: `_hash` is defined but never used)*
- `npm run build` *(fails due to TypeScript errors)*
- `node test/RetrnScoreEngine.test.ts` *(fails: unknown file extension .ts)*

------
https://chatgpt.com/codex/tasks/task_e_685795f9eff0833388010d9abc4be85a