### PR TITLE
Add category filter to trending API & hook

### DIFF
--- a/pages/api/trending.ts
+++ b/pages/api/trending.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
+    const category = req.query.category?.toString().toLowerCase();
     const filePath = path.join(process.cwd(), "thisrightnow", "public", "trending.json");
 
     if (!fs.existsSync(filePath)) {
@@ -11,7 +12,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     const raw = fs.readFileSync(filePath, "utf-8");
-    const data = JSON.parse(raw);
+    let data = JSON.parse(raw);
+
+    if (category) {
+      data = data.filter((p: any) => p.category?.toLowerCase() === category);
+    }
 
     res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate");
     res.status(200).json(data);

--- a/thisrightnow/public/trending.json
+++ b/thisrightnow/public/trending.json
@@ -7,7 +7,8 @@
     "retrns": 5,
     "boostTRN": 50,
     "resonance": 4.5,
-    "score": 85.32
+    "score": 85.32,
+    "category": "memes"
   },
   {
     "hash": "ipfs://bafkreighfakehash2",
@@ -17,6 +18,7 @@
     "retrns": 3,
     "boostTRN": 20,
     "resonance": 3.2,
-    "score": 60.25
+    "score": 60.25,
+    "category": "ai"
   }
 ]

--- a/thisrightnow/src/utils/useTrending.ts
+++ b/thisrightnow/src/utils/useTrending.ts
@@ -3,8 +3,9 @@ import useSWR from "swr";
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export function useTrending(category?: string) {
+  const query = category ? `?category=${encodeURIComponent(category)}` : "";
   const { data, error, isLoading } = useSWR(
-    category ? `/api/trending?category=${category}` : `/api/trending`,
+    `/api/trending${query}`,
     fetcher,
     { refreshInterval: 60000 }
   );


### PR DESCRIPTION
## Summary
- filter `/api/trending` results by `?category=` query
- use encoded category in `useTrending`
- add sample categories in `trending.json`

## Testing
- `npm run lint` *(fails: '_hash' is defined but never used)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685797558e888333a605838fc3d6397b