### PR TITLE
Add expandable leaderboard rows with breakdown

### DIFF
--- a/thisrightnow/src/components/UserEarningsBreakdown.tsx
+++ b/thisrightnow/src/components/UserEarningsBreakdown.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+export default function UserEarningsBreakdown({ addr }: { addr: string }) {
+  const [parts, setParts] = useState<{ merkle: number; vault: number; posts: number }>({
+    merkle: 0,
+    vault: 0,
+    posts: 0,
+  });
+
+  useEffect(() => {
+    const load = async () => {
+      const [m, v1, v2, p] = await Promise.all([
+        fetch("/src/data/merkle-2025-06-18.json").then((r) => r.json()),
+        fetch("/src/data/vault-investor.json").then((r) => r.json()),
+        fetch("/src/data/vault-contributor.json").then((r) => r.json()),
+        fetch("/src/data/post-earnings.json").then((r) => r.json()),
+      ]);
+
+      const lc = addr.toLowerCase();
+      setParts({
+        merkle: m[lc] || 0,
+        vault: (v1[lc] || 0) + (v2[lc] || 0),
+        posts: p[lc] || 0,
+      });
+    };
+
+    load();
+  }, [addr]);
+
+  const total = parts.merkle + parts.vault + parts.posts;
+
+  return (
+    <div>
+      <div>
+        Merkle: <span className="text-green-600">{parts.merkle.toFixed(3)} TRN</span>
+      </div>
+      <div>
+        Vaults: <span className="text-blue-600">{parts.vault.toFixed(3)} TRN</span>
+      </div>
+      <div>
+        Posts: <span className="text-purple-600">{parts.posts.toFixed(3)} TRN</span>
+      </div>
+      <div className="mt-1 text-xs text-gray-600">Total: {total.toFixed(3)} TRN</div>
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/analytics/leaderboard.tsx
+++ b/thisrightnow/src/pages/analytics/leaderboard.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import UserEarningsBreakdown from "@/components/UserEarningsBreakdown";
 
 export default function LeaderboardPage() {
   const [data, setData] = useState<any[]>([]);
   const [total, setTotal] = useState(0);
+  const [expandedAddr, setExpandedAddr] = useState<string | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -35,21 +37,37 @@ export default function LeaderboardPage() {
         </thead>
         <tbody>
           {data.map((row, i) => (
-            <tr key={row.addr} className="border-t">
-              <td className="p-2">{i + 1}</td>
-              <td className="p-2">{row.addr.slice(0, 6)}…{row.addr.slice(-4)}</td>
-              <td className="p-2 text-right text-green-700">
-                {row.amount.toFixed(3)}
-              </td>
-              <td className="p-2 text-right text-gray-500">
-                {((row.amount / total) * 100).toFixed(2)}%
-              </td>
-              <td className="p-2 text-right">
-                <Link href={`/account/${row.addr}/earnings`} className="text-blue-600 underline">
-                  View →
-                </Link>
-              </td>
-            </tr>
+            <>
+              <tr
+                key={row.addr}
+                className="border-t bg-white hover:bg-gray-50 cursor-pointer"
+                onClick={() =>
+                  setExpandedAddr(expandedAddr === row.addr ? null : row.addr)
+                }
+              >
+                <td className="p-2">{i + 1}</td>
+                <td className="p-2">{row.addr.slice(0, 6)}…{row.addr.slice(-4)}</td>
+                <td className="p-2 text-right text-green-700">
+                  {row.amount.toFixed(3)}
+                </td>
+                <td className="p-2 text-right text-gray-500">
+                  {((row.amount / total) * 100).toFixed(2)}%
+                </td>
+                <td className="p-2 text-right">
+                  <Link href={`/account/${row.addr}/earnings`} className="text-blue-600 underline">
+                    View →
+                  </Link>
+                </td>
+              </tr>
+
+              {expandedAddr === row.addr && (
+                <tr className="bg-gray-100 border-b text-sm">
+                  <td colSpan={5} className="p-4">
+                    <UserEarningsBreakdown addr={row.addr} />
+                  </td>
+                </tr>
+              )}
+            </>
           ))}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- allow rows in the leaderboard to be expanded
- fetch per-user earnings info from local JSONs
- show details via new `UserEarningsBreakdown` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857a89f29bc8333b49191c8ac1d887e