### PR TITLE
Add 7-key vault initialization and recovery scaffold

### DIFF
--- a/thisrightnow/src/App.tsx
+++ b/thisrightnow/src/App.tsx
@@ -5,6 +5,9 @@ import { mainnet } from 'wagmi/chains';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Home from './pages/index';
 import TRNBalanceHUD from '@/components/TRNBalanceHUD';
+import VaultInit from '@/components/VaultInit';
+import VaultRecovery from '@/components/VaultRecovery';
+import { useVaultStatus } from '@/hooks/useVaultStatus';
 
 const config = getDefaultConfig({
   appName: 'ThisRightNow',
@@ -18,6 +21,16 @@ const config = getDefaultConfig({
 const queryClient = new QueryClient();
 
 export default function App() {
+  const { initialized, unlocked } = useVaultStatus();
+
+  if (!initialized) {
+    return <VaultInit onComplete={() => location.reload()} />;
+  }
+
+  if (!unlocked) {
+    return <VaultRecovery onUnlock={() => location.reload()} />;
+  }
+
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>

--- a/thisrightnow/src/components/VaultInit.tsx
+++ b/thisrightnow/src/components/VaultInit.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+const defaultKeys = [
+  "Voice",
+  "Face",
+  "Thumb",
+  "Passphrase",
+  "QR Code",
+  "Backup Email",
+  "AI Auth",
+];
+
+export default function VaultInit({ onComplete }: { onComplete: () => void }) {
+  const [keys, setKeys] = useState<string[]>([]);
+  const [error, setError] = useState("");
+
+  const toggleKey = (k: string) => {
+    setKeys((prev) =>
+      prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
+    );
+  };
+
+  const handleSubmit = () => {
+    if (keys.length !== 7) {
+      setError("You must initialize with exactly 7 keys.");
+      return;
+    }
+
+    // Simulate local vault setup (store in localStorage for now)
+    localStorage.setItem("ado.vault.keys", JSON.stringify(keys));
+    localStorage.setItem("ado.vault.initialized", "true");
+    setError("");
+    onComplete();
+  };
+
+  return (
+    <div className="p-6 bg-white rounded shadow max-w-md mx-auto mt-10">
+      <h2 className="text-xl font-bold mb-4">🔐 Initialize Your Vault</h2>
+      <p className="mb-2 text-sm text-gray-600">
+        Choose exactly 7 identity keys to secure your vault:
+      </p>
+
+      <div className="grid grid-cols-2 gap-2 mb-4">
+        {defaultKeys.map((k) => (
+          <button
+            key={k}
+            onClick={() => toggleKey(k)}
+            className={`px-3 py-1 rounded border ${
+              keys.includes(k) ? "bg-green-600 text-white" : "bg-gray-100"
+            }`}
+          >
+            {k}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+
+      <button
+        onClick={handleSubmit}
+        className="w-full bg-black text-white py-2 rounded"
+      >
+        Lock Vault
+      </button>
+    </div>
+  );
+}

--- a/thisrightnow/src/components/VaultRecovery.tsx
+++ b/thisrightnow/src/components/VaultRecovery.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+
+const defaultKeys = [
+  "Voice",
+  "Face",
+  "Thumb",
+  "Passphrase",
+  "QR Code",
+  "Backup Email",
+  "AI Auth",
+];
+
+export default function VaultRecovery({ onUnlock }: { onUnlock: () => void }) {
+  const [keys, setKeys] = useState<string[]>([]);
+  const [error, setError] = useState("");
+
+  const stored = JSON.parse(localStorage.getItem("ado.vault.keys") || "[]");
+
+  const toggleKey = (k: string) => {
+    setKeys((prev) =>
+      prev.includes(k) ? prev.filter((x) => x !== k) : [...prev, k]
+    );
+  };
+
+  const handleSubmit = () => {
+    const match = keys.filter((k) => stored.includes(k)).length;
+    if (match >= 4) {
+      localStorage.setItem("ado.vault.unlocked", "true");
+      setError("");
+      onUnlock();
+    } else {
+      setError("Need at least 4 correct keys to unlock vault.");
+    }
+  };
+
+  return (
+    <div className="p-6 bg-white rounded shadow max-w-md mx-auto mt-10">
+      <h2 className="text-xl font-bold mb-4">🛠 Recover Your Vault</h2>
+      <p className="mb-2 text-sm text-gray-600">Select 4 of your saved keys to unlock:</p>
+
+      <div className="grid grid-cols-2 gap-2 mb-4">
+        {defaultKeys.map((k) => (
+          <button
+            key={k}
+            onClick={() => toggleKey(k)}
+            className={`px-3 py-1 rounded border ${
+              keys.includes(k) ? "bg-blue-600 text-white" : "bg-gray-100"
+            }`}
+          >
+            {k}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+
+      <button
+        onClick={handleSubmit}
+        className="w-full bg-black text-white py-2 rounded"
+      >
+        Unlock Vault
+      </button>
+    </div>
+  );
+}

--- a/thisrightnow/src/hooks/useVaultStatus.ts
+++ b/thisrightnow/src/hooks/useVaultStatus.ts
@@ -1,0 +1,5 @@
+export function useVaultStatus() {
+  const initialized = localStorage.getItem("ado.vault.initialized") === "true";
+  const unlocked = localStorage.getItem("ado.vault.unlocked") === "true";
+  return { initialized, unlocked };
+}


### PR DESCRIPTION
## Summary
- add `VaultInit` and `VaultRecovery` components
- add `useVaultStatus` hook
- gate `App` with vault initialization and recovery flow

## Testing
- `npm run lint` in `thisrightnow`
- `npm test` in `ado-core`
- `npx --yes ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_6857abcb30548333a082eae374e0d823