### PR TITLE
Add vault gating and new pages

### DIFF
--- a/thisrightnow/src/components/CreatePost.tsx
+++ b/thisrightnow/src/components/CreatePost.tsx
@@ -1,9 +1,21 @@
 import { useState } from "react";
 import { submitPost } from "@/utils/submitPost";
+import { useVaultStatus } from "@/hooks/useVaultStatus";
 
 export default function CreatePost() {
+  const { initialized, unlocked } = useVaultStatus();
   const [text, setText] = useState("");
   const [tags, setTags] = useState("");
+
+  if (!initialized || !unlocked) {
+    return (
+      <div className="p-4 bg-yellow-100 border border-yellow-400 text-yellow-800 rounded">
+        🔒 You must unlock your Vault to post.
+        <br />
+        Go to <a href="/vault" className="underline">Vault Setup</a>.
+      </div>
+    );
+  }
 
   const handleSubmit = async () => {
     if (!text || text.length < 3) {

--- a/thisrightnow/src/components/CreateProposal.tsx
+++ b/thisrightnow/src/components/CreateProposal.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { useVaultStatus } from "@/hooks/useVaultStatus";
+
+export default function CreateProposal() {
+  const { initialized, unlocked } = useVaultStatus();
+  const [text, setText] = useState("");
+
+  if (!initialized || !unlocked) {
+    return (
+      <div className="p-6 bg-red-100 text-red-800 border border-red-400 rounded">
+        🛡 Vault Required to Submit Proposals.
+        <br />
+        <a href="/vault" className="underline">Initialize your Vault</a> to unlock DAO permissions.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-6">
+      <textarea
+        className="w-full border p-2"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Proposal details"
+      />
+      <button
+        disabled={!unlocked}
+        className={`w-full mt-4 py-2 rounded ${
+          unlocked ? "bg-black text-white" : "bg-gray-300 text-gray-600 cursor-not-allowed"
+        }`}
+      >
+        Submit Proposal
+      </button>
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/proposal.tsx
+++ b/thisrightnow/src/pages/proposal.tsx
@@ -1,0 +1,5 @@
+import CreateProposal from "@/components/CreateProposal";
+
+export default function ProposalPage() {
+  return <CreateProposal />;
+}

--- a/thisrightnow/src/pages/vault.tsx
+++ b/thisrightnow/src/pages/vault.tsx
@@ -1,0 +1,17 @@
+import { useVaultStatus } from "@/hooks/useVaultStatus";
+import VaultInit from "@/components/VaultInit";
+import VaultRecovery from "@/components/VaultRecovery";
+
+export default function VaultPage() {
+  const { initialized, unlocked } = useVaultStatus();
+
+  if (!initialized) return <VaultInit onComplete={() => location.reload()} />;
+  if (!unlocked) return <VaultRecovery onUnlock={() => location.reload()} />;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold">✅ Vault Unlocked</h1>
+      <p className="mt-2 text-green-600">You now have full access to post, vote, and earn.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- gate posting behind vault unlock
- add proposal creation component gated by vault
- expose `/proposal` and `/vault` pages
- include submit button styling for proposal gating

## Testing
- `npm run lint` in `thisrightnow`
- `npx hardhat test` in `ado-core`
- `npx ts-node test/RetrnScoreEngine.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6857ad6eeae08333b7f8674e37500247