### PR TITLE
Add trust score hook integration

### DIFF
--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -21,7 +21,7 @@ export default function PostCard({
   const [retrns, setRetrns] = useState<any[]>([]);
   const [earnings, setEarnings] = useState<number | null>(null);
   const author = post?.author || data?.author;
-  const trust = useTrustScore(author);
+  const trust = useTrustScore(post?.author);
 
   useEffect(() => {
     if (!post) fetchPost(ipfsHash).then(setData).catch(console.error);
@@ -52,8 +52,8 @@ export default function PostCard({
 
   return (
     <div className="bg-white border rounded p-4 shadow-sm">
-      <div className="text-sm text-gray-600 mb-1">
-        <span>{author}</span>
+      <span className="text-sm text-gray-600">
+        {author?.slice(0, 8)}...
         {trust && (
           <span
             className={`ml-2 px-2 py-1 text-xs rounded font-bold ${
@@ -67,7 +67,16 @@ export default function PostCard({
             Trust: {trust.score}
           </span>
         )}
-      </div>
+      </span>
+      {trust && (
+        <div className="text-xs text-gray-500 mt-1">
+          {trust.score >= 80
+            ? "Trusted Contributor"
+            : trust.score >= 50
+            ? "Neutral Contributor"
+            : "Low Trust Score"}
+        </div>
+      )}
       <p>{data.content}</p>
       <div className="text-xs text-gray-500 mt-2">
         {data.tags?.join(", ")} · {new Date(data.timestamp).toLocaleString()}

--- a/thisrightnow/src/hooks/useTrustScore.ts
+++ b/thisrightnow/src/hooks/useTrustScore.ts
@@ -1,12 +1,15 @@
-const MOCK_TRUST: Record<string, number> = {
-  "0xUserOne": 92,
+const MOCK_TRUST_SCORES: Record<string, number> = {
+  "0xUserOne": 91,
   "0xBotGuy": 23,
-  "0xModLady": 88,
+  "0xModLady": 87,
 };
 
 export function useTrustScore(addr?: string) {
-  const score = addr
-    ? MOCK_TRUST[addr] ?? Math.floor(Math.random() * 60) + 20
-    : undefined;
-  return addr ? { score } : undefined;
+  if (!addr) return null;
+
+  // Mock logic: if we have a real address in mock list, use it — otherwise randomize
+  const score =
+    MOCK_TRUST_SCORES[addr] ?? Math.floor(Math.random() * 60) + 20;
+
+  return { score };
 }


### PR DESCRIPTION
## Summary
- add trust score helper to frontend hooks
- show trust score for post authors

## Testing
- `npm test` within `ado-core`
- `npm run lint` within `thisrightnow`


------
https://chatgpt.com/codex/tasks/task_e_685811bb020c8333ab2c86ba6f529ae1