### PR TITLE
Implement vault encryption and IPFS pinning

### DIFF
--- a/thisrightnow/src/utils/encryptVault.ts
+++ b/thisrightnow/src/utils/encryptVault.ts
@@ -1,0 +1,24 @@
+export async function encryptVault(keys: string[], passphrase: string) {
+  const enc = new TextEncoder();
+  const rawKey = await window.crypto.subtle.importKey(
+    "raw",
+    enc.encode(passphrase),
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const payload = JSON.stringify({ keys });
+
+  const encrypted = await window.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    rawKey,
+    enc.encode(payload)
+  );
+
+  return {
+    encrypted: Buffer.from(encrypted).toString("base64"),
+    iv: Buffer.from(iv).toString("base64"),
+  };
+}

--- a/thisrightnow/src/utils/pinVaultToIPFS.ts
+++ b/thisrightnow/src/utils/pinVaultToIPFS.ts
@@ -1,0 +1,7 @@
+// Replace with actual IPFS client later
+export async function pinVaultToIPFS(data: any): Promise<string> {
+  // Simulate IPFS CID for now
+  const hash = "bafy" + Math.random().toString(36).slice(2, 10);
+  console.log("\ud83d\udd10 Pinned Vault:", JSON.stringify(data, null, 2));
+  return hash;
+}


### PR DESCRIPTION
## Summary
- add utility to encrypt a vault locally
- add helper to simulate pinning to IPFS
- update VaultInit to encrypt and pin vault data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858149fdcc883338232682065ae9932