### PR TITLE
Add eTRN_id trust gate

### DIFF
--- a/thisrightnow/src/abi/ContributorNFT.json
+++ b/thisrightnow/src/abi/ContributorNFT.json
@@ -1,0 +1,16 @@
+[
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "hasMinted",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getVaultCID",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/components/TrustGate.tsx
+++ b/thisrightnow/src/components/TrustGate.tsx
@@ -1,0 +1,46 @@
+import { useAccount } from "wagmi";
+import { useEffect, useState } from "react";
+import { loadContract } from "@/utils/contract";
+import ContributorNFT from "@/abi/ContributorNFT.json";
+
+export default function TrustGate({ children }: { children: React.ReactNode }) {
+  const { address } = useAccount();
+  const [hasAccess, setHasAccess] = useState(false);
+
+  useEffect(() => {
+    if (!address) return;
+    const check = async () => {
+      try {
+        const contract = await loadContract(
+          "ContributorNFT",
+          ContributorNFT as any,
+        );
+        const minted = await (contract as any).hasMinted(address);
+        const cid = await (contract as any).getVaultCID(address);
+        if (minted && cid.length > 0) {
+          setHasAccess(true);
+        }
+      } catch (err) {
+        console.error("eTRN_id check failed", err);
+      }
+    };
+    check();
+  }, [address]);
+
+  if (!address) return <p>Connect wallet to continue.</p>;
+  if (!hasAccess)
+    return (
+      <div className="bg-yellow-100 p-4 rounded text-sm text-yellow-800">
+        <p>
+          ⚠️ You need to mint your
+          <strong>eTRN_id — your verified identity key to the ADO ecosystem</strong>
+          to use this feature.
+        </p>
+        <a href="/mint" className="underline text-blue-600">
+          Go mint now →
+        </a>
+      </div>
+    );
+
+  return <>{children}</>;
+}

--- a/thisrightnow/src/pages/boost.tsx
+++ b/thisrightnow/src/pages/boost.tsx
@@ -4,6 +4,7 @@ import { loadContract } from "@/utils/contract";
 import BoostingModuleABI from "@/abi/BoostingModule.json";
 import { getOracleBalance } from "@/utils/oracle";
 import { useAccount } from "wagmi";
+import TrustGate from "@/components/TrustGate";
 
 export default function BoostPage() {
   const { address } = useAccount();
@@ -50,7 +51,8 @@ export default function BoostPage() {
   };
 
   return (
-    <div className="max-w-xl mx-auto p-6">
+    <TrustGate>
+      <div className="max-w-xl mx-auto p-6">
       <h1 className="text-2xl font-bold mb-6">🚀 Boost a Post</h1>
 
       <div className="space-y-4">
@@ -112,5 +114,6 @@ export default function BoostPage() {
         {status && <p className="mt-3 text-sm text-gray-700">{status}</p>}
       </div>
     </div>
+    </TrustGate>
   );
 }

--- a/thisrightnow/src/pages/proposal.tsx
+++ b/thisrightnow/src/pages/proposal.tsx
@@ -1,5 +1,10 @@
 import CreateProposal from "@/components/CreateProposal";
+import TrustGate from "@/components/TrustGate";
 
 export default function ProposalPage() {
-  return <CreateProposal />;
+  return (
+    <TrustGate>
+      <CreateProposal />
+    </TrustGate>
+  );
 }


### PR DESCRIPTION
## Summary
- implement `TrustGate` component for eTRN_id verification
- stub `ContributorNFT` ABI
- gate boost and proposal pages behind `TrustGate`

## Testing
- `npx hardhat test` *(fails: needs hardhat package)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: needs ts-node package)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858319ddfe88333991fb8b4c804ac9b