### PR TITLE
Add trust score overlay hook

### DIFF
--- a/thisrightnow/src/components/PostCard.tsx
+++ b/thisrightnow/src/components/PostCard.tsx
@@ -20,8 +20,7 @@ export default function PostCard({
   const [data, setData] = useState(post || null);
   const [retrns, setRetrns] = useState<any[]>([]);
   const [earnings, setEarnings] = useState<number | null>(null);
-  const author = post?.author || data?.author;
-  const trust = useTrustScore(post?.author);
+  const trust = useTrustScore(post.author);
 
   useEffect(() => {
     if (!post) fetchPost(ipfsHash).then(setData).catch(console.error);
@@ -52,31 +51,23 @@ export default function PostCard({
 
   return (
     <div className="bg-white border rounded p-4 shadow-sm">
-      <span className="text-sm text-gray-600">
-        {author?.slice(0, 8)}...
+      <div className="text-sm text-gray-600 flex items-center space-x-2">
+        <span className="font-mono">{post.author}</span>
+
         {trust && (
           <span
-            className={`ml-2 px-2 py-1 text-xs rounded font-bold ${
+            className={`px-2 py-0.5 text-xs rounded font-bold ${
               trust.score >= 80
                 ? "bg-green-200 text-green-800"
                 : trust.score >= 50
-                ? "bg-yellow-200 text-yellow-800"
-                : "bg-red-200 text-red-800"
+                ? "bg-yellow-100 text-yellow-700"
+                : "bg-red-100 text-red-600"
             }`}
           >
             Trust: {trust.score}
           </span>
         )}
-      </span>
-      {trust && (
-        <div className="text-xs text-gray-500 mt-1">
-          {trust.score >= 80
-            ? "Trusted Contributor"
-            : trust.score >= 50
-            ? "Neutral Contributor"
-            : "Low Trust Score"}
-        </div>
-      )}
+      </div>
       <p>{data.content}</p>
       <div className="text-xs text-gray-500 mt-2">
         {data.tags?.join(", ")} · {new Date(data.timestamp).toLocaleString()}

--- a/thisrightnow/src/hooks/useTrustScore.ts
+++ b/thisrightnow/src/hooks/useTrustScore.ts
@@ -1,15 +1,17 @@
-const MOCK_TRUST_SCORES: Record<string, number> = {
-  "0xUserOne": 91,
-  "0xBotGuy": 23,
-  "0xModLady": 87,
+// A lightweight trust hook for now, wired to mock data
+const MOCK_TRUST: Record<string, number> = {
+  "0xMOD123...": 92,
+  "0xBOT456...": 25,
+  "0xALPHA...": 88,
 };
 
-export function useTrustScore(addr?: string) {
-  if (!addr) return null;
-
-  // Mock logic: if we have a real address in mock list, use it — otherwise randomize
-  const score =
-    MOCK_TRUST_SCORES[addr] ?? Math.floor(Math.random() * 60) + 20;
-
+export function useTrustScore(address: string) {
+  const normalized = address.toLowerCase();
+  const score = MOCK_TRUST[normalized] ?? Math.floor(Math.random() * 60) + 30;
   return { score };
 }
+
+// Later, replace this with calls to:
+// - TrustScoreEngine.ts
+// - ModerationLog indexer
+// - Vault + AI training signals


### PR DESCRIPTION
## Summary
- implement lightweight mock `useTrustScore` hook
- show trust badge on each post via `PostCard`

## Testing
- `npx --yes ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint` in `thisrightnow` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858465646d0833388d67b37e74845a1