### PR TITLE
Add vault IPFS sync utilities

### DIFF
--- a/thisrightnow/src/components/VaultInit.tsx
+++ b/thisrightnow/src/components/VaultInit.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { encryptVault } from "@/utils/encryptVault";
 import { pinVaultToIPFS } from "@/utils/pinVaultToIPFS";
+import { uploadVaultKeys } from "@/utils/uploadVaultKeys";
 
 const defaultKeys = [
   "Voice",
@@ -36,9 +37,11 @@ export default function VaultInit({ onComplete }: { onComplete: () => void }) {
       return;
     }
 
+    const userAddress = (window as any).ethereum?.selectedAddress || "anon";
+
     const encrypted = await encryptVault(keys, passphrase);
     const payload = {
-      address: (window as any).ethereum.selectedAddress || "anon",
+      address: userAddress,
       createdAt: Date.now(),
       encryptedVault: encrypted.encrypted,
       iv: encrypted.iv,
@@ -53,6 +56,7 @@ export default function VaultInit({ onComplete }: { onComplete: () => void }) {
     // Save metadata locally
     localStorage.setItem("ado.vault.cid", cid);
     localStorage.setItem("ado.vault.initialized", "true");
+    await uploadVaultKeys(keys, userAddress);
     setError("");
     onComplete();
   };

--- a/thisrightnow/src/components/VaultRecovery.tsx
+++ b/thisrightnow/src/components/VaultRecovery.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { decryptVault } from "@/utils/decryptVault";
+import { fetchFromIPFS } from "@/utils/ipfs";
 
 export default function VaultRecovery({ onUnlock }: { onUnlock: () => void }) {
   const [passphrase, setPassphrase] = useState("");
@@ -24,6 +25,11 @@ export default function VaultRecovery({ onUnlock }: { onUnlock: () => void }) {
 
       console.log("\ud83d\udd13 Vault Restored Keys:", keys);
       localStorage.setItem("ado.vault.unlocked", "true");
+      const hash = localStorage.getItem("ado.vault.ipfsHash");
+      if (hash) {
+        const remoteVault = await fetchFromIPFS(hash);
+        console.log("\ud83d\udd10 Remote Vault Keys", remoteVault);
+      }
       onUnlock();
     } catch (err: any) {
       setError(err.message);

--- a/thisrightnow/src/pages/vault/sync.tsx
+++ b/thisrightnow/src/pages/vault/sync.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function VaultSyncPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">\ud83d\udd10 Vault Sync</h1>
+      <p className="mb-4">Manage your vault keys and backups.</p>
+      <ul className="list-disc pl-4 space-y-2">
+        <li>Re-upload updated vault keys</li>
+        <li>Attach ENS or alias metadata</li>
+        <li>Export backup ZIP of your soulbound identity</li>
+      </ul>
+      <div className="mt-6">
+        <Link href="/vault" className="text-blue-600">
+          \u2190 Back to Vault
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/thisrightnow/src/utils/ipfs.ts
+++ b/thisrightnow/src/utils/ipfs.ts
@@ -1,0 +1,9 @@
+import { uploadToIPFS as upload } from "./uploadToIPFS";
+
+export const uploadToIPFS = upload;
+
+export async function fetchFromIPFS(hash: string): Promise<any> {
+  const cid = hash.replace("ipfs://", "");
+  const res = await fetch(`https://nftstorage.link/ipfs/${cid}`);
+  return res.json();
+}

--- a/thisrightnow/src/utils/uploadVaultKeys.ts
+++ b/thisrightnow/src/utils/uploadVaultKeys.ts
@@ -1,0 +1,14 @@
+import { uploadToIPFS } from "@/utils/ipfs";
+
+export async function uploadVaultKeys(keys: string[], userAddress: string) {
+  const data = {
+    address: userAddress,
+    keys,
+    timestamp: Date.now(),
+  };
+
+  const ipfsHash = await uploadToIPFS(data);
+  localStorage.setItem("ado.vault.ipfsHash", ipfsHash);
+
+  return ipfsHash;
+}


### PR DESCRIPTION
## Summary
- add generic IPFS helper with fetch capability
- add `uploadVaultKeys` util for persisting vault keys to IPFS
- upload keys during vault initialization
- retrieve uploaded keys when recovering a vault
- stub `/vault/sync` page for future vault management

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx hardhat test` *(fails: need to install hardhat)*


------
https://chatgpt.com/codex/tasks/task_e_685848bc50608333b496e748a4e9ac53