### PR TITLE
Add trust-based weighting utility

### DIFF
--- a/thisrightnow/src/utils/TrustWeightedOracle.ts
+++ b/thisrightnow/src/utils/TrustWeightedOracle.ts
@@ -1,0 +1,29 @@
+import { fetchTrustScore } from "@/utils/fetchTrustScore";
+
+/**
+ * Scales TRN values by user trust level.
+ * Applies platform-wide fairness adjustment.
+ *
+ * @param address - The user wallet address
+ * @param baseAmount - The base TRN value
+ * @returns trust-weighted TRN value
+ */
+export async function applyTrustWeight(
+  address: string,
+  baseAmount: number
+): Promise<number> {
+  const trust = await fetchTrustScore(address);
+
+  if (trust >= 90) return baseAmount * 1.25;
+  if (trust >= 75) return baseAmount * 1.1;
+  if (trust >= 50) return baseAmount;
+  if (trust >= 30) return baseAmount * 0.6;
+  return baseAmount * 0.3;
+}
+
+/**
+ * Example use:
+ *
+ * const weightedTRN = await applyTrustWeight(userAddr, 10);
+ * await oracle.rewardUser(userAddr, weightedTRN);
+ */

--- a/thisrightnow/src/utils/engagement.ts
+++ b/thisrightnow/src/utils/engagement.ts
@@ -3,7 +3,7 @@ import BlessBurnABI from "@/abi/BlessBurnTracker.json";
 import BoostingModuleABI from "@/abi/BoostingModule.json";
 import OracleABI from "@/abi/TRNUsageOracle.json";
 import { loadContract } from "./contract";
-import { applyTrustWeight } from "../../../shared/TrustWeightedOracle";
+import { applyTrustWeight } from "@/utils/TrustWeightedOracle";
 
 export async function blessPost(postHash: string) {
   const tracker = await loadContract("BlessBurnTracker", BlessBurnABI as any);

--- a/thisrightnow/src/utils/fetchTrustScore.ts
+++ b/thisrightnow/src/utils/fetchTrustScore.ts
@@ -1,0 +1,9 @@
+const MOCK_TRUST: Record<string, number> = {
+  "0xtrustedalpha...": 94,
+  "0xbotfarm123...": 22,
+};
+
+export async function fetchTrustScore(address: string): Promise<number> {
+  const normalized = address.toLowerCase();
+  return MOCK_TRUST[normalized] ?? Math.floor(Math.random() * 40 + 30);
+}

--- a/thisrightnow/src/utils/submitRetrn.ts
+++ b/thisrightnow/src/utils/submitRetrn.ts
@@ -3,7 +3,7 @@ import ViewIndexABI from "@/abi/ViewIndex.json";
 import OracleABI from "@/abi/TRNUsageOracle.json";
 import { loadContract } from "./contract";
 import { uploadToIPFS } from "./uploadToIPFS";
-import { applyTrustWeight } from "../../../shared/TrustWeightedOracle";
+import { applyTrustWeight } from "@/utils/TrustWeightedOracle";
 import { ethers } from "ethers";
 
 export async function submitRetrn(


### PR DESCRIPTION
## Summary
- add new TrustWeightedOracle helper in frontend utils
- scaffold fetchTrustScore mock
- point engagement and submitRetrn helpers to new oracle util

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx hardhat test` *(fails: needs interactive install)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: needs interactive install)*

------
https://chatgpt.com/codex/tasks/task_e_68584da6d088833399de1b33b3637591