### PR TITLE
Wire trust weighting into boosts

### DIFF
--- a/thisrightnow/src/pages/boost.tsx
+++ b/thisrightnow/src/pages/boost.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { formatEther, parseEther } from "ethers";
-import { boostPost } from "@/utils/engagement";
+import { boostPost } from "@/utils/boostPost";
+import { applyTrustWeight } from "@/utils/TrustWeightedOracle";
 import { getOracleBalance } from "@/utils/oracle";
 import { useAccount } from "wagmi";
 
@@ -10,11 +11,20 @@ export default function BoostPage() {
   const [amount, setAmount] = useState("5");
   const [status, setStatus] = useState("");
   const [oracleTRN, setOracleTRN] = useState("0");
+  const [weightedTRN, setWeightedTRN] = useState(0);
 
   useEffect(() => {
     if (!address) return;
     getOracleBalance(address).then(setOracleTRN);
   }, [address]);
+
+  useEffect(() => {
+    if (!address) {
+      setWeightedTRN(0);
+      return;
+    }
+    applyTrustWeight(address, parseFloat(amount || "0")).then(setWeightedTRN);
+  }, [address, amount]);
 
   const canBoost = parseEther(amount || "0") <= BigInt(oracleTRN);
   const usageRatio =
@@ -83,6 +93,9 @@ export default function BoostPage() {
 
             <p className="text-xs text-gray-500 mt-1">
               Using {amount || "0"} / {formatEther(oracleTRN)} TRN
+            </p>
+            <p className="text-sm text-gray-500">
+              Boost power adjusted for trust: <strong>{weightedTRN.toFixed(2)} TRN</strong>
             </p>
           </div>
         </div>

--- a/thisrightnow/src/utils/boostPost.ts
+++ b/thisrightnow/src/utils/boostPost.ts
@@ -1,0 +1,23 @@
+import { ethers } from "ethers";
+import BoostingModuleABI from "@/abi/BoostingModule.json";
+import { loadContract } from "./contract";
+import { applyTrustWeight } from "@/utils/TrustWeightedOracle";
+
+export async function boostPost(ipfsHash: string, baseTRN: number): Promise<string> {
+  const provider = new ethers.BrowserProvider(
+    (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+  );
+  const signer = await provider.getSigner();
+  const userAddr = await signer.getAddress();
+
+  const weightedTRN = await applyTrustWeight(userAddr, baseTRN);
+
+  const contract = await loadContract("BoostingModule", BoostingModuleABI as any);
+  const tx = await (contract as any).startBoost(
+    ethers.encodeBytes32String(ipfsHash),
+    ethers.parseEther(weightedTRN.toString())
+  );
+  await tx.wait();
+
+  return tx.hash as string;
+}

--- a/thisrightnow/src/utils/engagement.ts
+++ b/thisrightnow/src/utils/engagement.ts
@@ -1,6 +1,5 @@
 import { ethers } from "ethers";
 import BlessBurnABI from "@/abi/BlessBurnTracker.json";
-import BoostingModuleABI from "@/abi/BoostingModule.json";
 import OracleABI from "@/abi/TRNUsageOracle.json";
 import { loadContract } from "./contract";
 import { applyTrustWeight } from "@/utils/TrustWeightedOracle";
@@ -35,14 +34,3 @@ export async function burnPost(postHash: string) {
   await (oracle as any).reportBurn(addr, ethers.parseEther(amount.toString()), hashBytes);
 }
 
-export async function boostPost(postHash: string, baseTRN: number) {
-  const provider = new ethers.BrowserProvider(
-    (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
-  );
-  const signer = await provider.getSigner();
-  const addr = await signer.getAddress();
-  const weighted = await applyTrustWeight(addr, baseTRN);
-  const contract = await loadContract("BoostingModule", BoostingModuleABI as any);
-  const hashBytes = ethers.encodeBytes32String(postHash);
-  await (contract as any).startBoost(hashBytes, ethers.parseEther(weighted.toString()));
-}


### PR DESCRIPTION
## Summary
- add dedicated `boostPost` utility that applies trust weighting before calling the BoostingModule
- show adjusted boost power in the Boost page
- remove old boost logic from engagement utils

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm run lint` in `thisrightnow/`


------
https://chatgpt.com/codex/tasks/task_e_68584fbffc7083339abf14a25456f76c