### PR TITLE
Add trust-weighted boost helper

### DIFF
--- a/thisrightnow/src/utils/signer.ts
+++ b/thisrightnow/src/utils/signer.ts
@@ -1,0 +1,7 @@
+export async function getSigner() {
+  const { ethers } = await import('ethers');
+  const provider = new ethers.BrowserProvider(
+    (window as unknown as { ethereum?: ethers.Eip1193Provider }).ethereum!
+  );
+  return provider.getSigner();
+}


### PR DESCRIPTION
## Summary
- add `getSigner` helper for re-use when fetching wallet signers
- update `boostPost` to use `getSigner` and log the trust adjustment

## Testing
- `node --loader ts-node/esm test/RetrnScoreEngine.test.ts` *(fails: Cannot find package 'ts-node')*
- `npx hardhat test` *(fails: package installation prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68585380e72483338e4e80febfc959b5