### PR TITLE
Add trust-weighted trending indexer

### DIFF
--- a/thisrightnow/src/utils/useTrending.ts
+++ b/thisrightnow/src/utils/useTrending.ts
@@ -3,15 +3,20 @@ import useSWR from "swr";
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export function useTrending(category?: string) {
-  const query = category ? `?category=${encodeURIComponent(category)}` : "";
   const { data, error, isLoading } = useSWR(
-    `/api/trending${query}`,
+    "/indexer/output/trending.json",
     fetcher,
     { refreshInterval: 60000 }
   );
 
+  let posts = (data as any[]) || [];
+  if (category) {
+    const cat = category.toLowerCase();
+    posts = posts.filter((p) => p.category?.toLowerCase() === cat);
+  }
+
   return {
-    posts: data || [],
+    posts,
     isLoading,
     isError: !!error,
   };


### PR DESCRIPTION
## Summary
- implement trust-weighted trendingIndexer script
- adjust `useTrending` hook to load from new indexer output

## Testing
- `npx hardhat test` *(fails: Hardhat not installed)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: ts-node not installed)*
- `npm run lint` in `thisrightnow` *(fails: missing ESLint deps)*
- `ts-node indexer/trendingIndexer.ts` *(fails: ts-node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68585ab17ea4833398fbddb700cc0c32