### PR TITLE
Add IPFS trending emission utility

### DIFF
--- a/indexer/emitTrending.ts
+++ b/indexer/emitTrending.ts
@@ -1,0 +1,16 @@
+import { generateTrendingScores } from "./trendingIndexer";
+import { uploadToIPFS } from "./utils/uploadToIPFS";
+import { writeFileSync } from "fs";
+import path from "path";
+
+async function emitTrending() {
+  const trending = await generateTrendingScores();
+
+  const filePath = path.join("thisrightnow", "public", "trending.json");
+  writeFileSync(filePath, JSON.stringify(trending, null, 2));
+
+  const ipfsHash = await uploadToIPFS(trending);
+  console.log(`🚀 Trending data pinned to IPFS: ${ipfsHash}`);
+}
+
+emitTrending().catch(console.error);

--- a/indexer/trendingIndexer.ts
+++ b/indexer/trendingIndexer.ts
@@ -14,7 +14,7 @@ export type TrendingScore = {
   boostTRN: number;
 };
 
-export async function generateTrendingScores() {
+export async function generateTrendingScores(): Promise<TrendingScore[]> {
   const viewIndex = await loadContract("ViewIndex", ViewIndexABI);
   const blessBurn = await loadContract("BlessBurnTracker", BlessBurnTrackerABI);
   const retrnIndex = await loadContract("RetrnIndex", RetrnIndexABI);
@@ -65,6 +65,7 @@ export async function generateTrendingScores() {
   scores.sort((a, b) => b.score - a.score);
   writeFileSync("indexer/output/trending.json", JSON.stringify(scores, null, 2));
   console.log("✅ Trending index updated.");
+  return scores;
 }
 
 if (require.main === module) {

--- a/indexer/utils/uploadToIPFS.ts
+++ b/indexer/utils/uploadToIPFS.ts
@@ -1,0 +1,9 @@
+import { NFTStorage } from "nft.storage";
+
+const client = new NFTStorage({ token: process.env.NFT_STORAGE_KEY! });
+
+export async function uploadToIPFS(data: any): Promise<string> {
+  const blob = new Blob([JSON.stringify(data)], { type: "application/json" });
+  const cid = await client.storeBlob(blob);
+  return `ipfs://${cid}`;
+}


### PR DESCRIPTION
## Summary
- add script to upload trending data to IPFS
- return trending scores from `generateTrendingScores`
- share upload helper in indexer

## Testing
- `npx hardhat test` *(fails: non-local installation)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: needs ts-node install)*
- `npm run lint` in `thisrightnow` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68585d3601088333a71ce647b18ac5e5