### PR TITLE
Implement vault recovery API stub

### DIFF
--- a/pages/api/recover.ts
+++ b/pages/api/recover.ts
@@ -1,21 +1,39 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+// Simulated structure for now — plug into actual contract call
+async function triggerVaultRecovery(shards: string[]): Promise<boolean> {
+  console.log("🔑 Attempting recovery with shards:", shards);
+
+  // Replace this with your actual smart contract call
+  const success = shards.length >= 4 && shards.every((s) => s.length > 10);
+
+  // Imagine calling: VaultRecovery.recoverWithShards(shards)
+  return success;
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" });
+    return res.status(405).json({ success: false, error: "Method not allowed" });
   }
 
-  const { shards } = req.body as { shards?: string[] };
-  if (!Array.isArray(shards) || shards.filter((s) => s.trim().length > 0).length < 4) {
-    return res.status(400).json({ success: false, error: "At least 4 shard keys required" });
+  const { shards } = req.body;
+
+  if (!Array.isArray(shards) || shards.length < 4) {
+    return res
+      .status(400)
+      .json({ success: false, error: "At least 4 shard keys required." });
   }
 
   try {
-    // TODO: Integrate on-chain VaultRecovery.sol logic
-    // For now we simply echo success
-    return res.status(200).json({ success: true });
+    const result = await triggerVaultRecovery(shards);
+    if (result) {
+      return res.status(200).json({ success: true });
+    } else {
+      return res.status(500).json({ success: false, error: "Recovery failed." });
+    }
   } catch (err) {
-    console.error("Recovery error", err);
-    return res.status(500).json({ success: false, error: "Internal error" });
+    console.error("Vault recovery error:", err);
+    return res.status(500).json({ success: false, error: "Unexpected error." });
   }
 }
+


### PR DESCRIPTION
## Summary
- update backend route `/api/recover` with a recovery stub

## Testing
- `npx hardhat test` *(fails: Hardhat not installed)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: missing dependencies)*
- `npm run lint` in `thisrightnow` *(fails: missing ESLint deps)*

------
https://chatgpt.com/codex/tasks/task_e_68586642b0988333840fb18ed0cfd56b