### PR TITLE
Implement trust score update util

### DIFF
--- a/test/updateTrustFromEngagement.test.ts
+++ b/test/updateTrustFromEngagement.test.ts
@@ -1,0 +1,13 @@
+import { updateTrustScoreFromEngagement } from '../utils/updateTrustFromEngagement';
+import { trustScoreMap } from '../utils/trustState';
+
+(async () => {
+  const user = '0xtrustedalpha...';
+  const before = trustScoreMap[user];
+  await updateTrustScoreFromEngagement(user, 'post1');
+  const after = trustScoreMap[user];
+  if (Number.isNaN(after) || after < 0 || after > 100) {
+    throw new Error('Trust score out of bounds');
+  }
+  console.log('✅ updateTrustFromEngagement test passed');
+})();

--- a/utils/metrics.ts
+++ b/utils/metrics.ts
@@ -1,0 +1,16 @@
+export type EngagementMetrics = {
+  views: number;
+  retrns: number;
+  blesses: number;
+  burns: number;
+  retrnBlessRatio: number;
+};
+
+export async function getEngagementMetrics(_postHash: string): Promise<EngagementMetrics> {
+  const views = Math.floor(Math.random() * 100);
+  const retrns = Math.floor(Math.random() * 10);
+  const blesses = Math.floor(Math.random() * 10);
+  const burns = Math.floor(Math.random() * 5);
+  const retrnBlessRatio = blesses ? retrns / blesses : 0;
+  return { views, retrns, blesses, burns, retrnBlessRatio };
+}

--- a/utils/moderation.ts
+++ b/utils/moderation.ts
@@ -1,0 +1,8 @@
+export type ModerationOutcome = 'approved' | 'flagged' | 'removed';
+
+export async function getModerationOutcome(_postHash: string): Promise<ModerationOutcome> {
+  const r = Math.random();
+  if (r < 0.1) return 'removed';
+  if (r < 0.3) return 'flagged';
+  return 'approved';
+}

--- a/utils/trustState.ts
+++ b/utils/trustState.ts
@@ -1,0 +1,4 @@
+export const trustScoreMap: Record<string, number> = {
+  "0xtrustedalpha...": 94,
+  "0xbotfarm123...": 22,
+};

--- a/utils/updateTrustFromEngagement.ts
+++ b/utils/updateTrustFromEngagement.ts
@@ -1,0 +1,29 @@
+import { getEngagementMetrics } from './metrics';
+import { getModerationOutcome } from './moderation';
+import { trustScoreMap } from './trustState';
+
+export async function updateTrustScoreFromEngagement(author: string, postHash: string): Promise<void> {
+  const trust = trustScoreMap[author.toLowerCase()] || 50;
+
+  const metrics = await getEngagementMetrics(postHash);
+  const modResult = await getModerationOutcome(postHash);
+
+  let delta = 0;
+
+  // \uD83D\uDCC8 Engagement-driven score updates
+  if (metrics.blesses > metrics.burns * 2) delta += 2;
+  if (metrics.retrns > 5) delta += 1;
+  if (metrics.views > 50) delta += 0.5;
+
+  // \u26A0\uFE0F Penalties for flags or removals
+  if (modResult === 'flagged') delta -= 3;
+  if (modResult === 'removed') delta -= 5;
+
+  // \uD83E\uDDEA Experimental bonus: retrn performance
+  if (metrics.retrnBlessRatio > 1.5) delta += 1;
+
+  const newScore = Math.max(0, Math.min(100, trust + delta));
+  trustScoreMap[author.toLowerCase()] = newScore;
+
+  console.log(`\uD83D\uDD01 Trust updated for ${author}: ${trust} \u2192 ${newScore}`);
+}


### PR DESCRIPTION
## Summary
- implement engagement metrics and moderation stubs
- add trustState mapping
- create `updateTrustFromEngagement` utility and test

## Testing
- `npx ts-node test/updateTrustFromEngagement.test.ts`
- `npx ts-node test/BlessBurnTracker.test.ts`
- `npx ts-node test/FlagEscalationAI.test.ts`
- `npx ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_685872c34b8483338ded817ccd6efeb4