### PR TITLE
Add trust log admin UI

### DIFF
--- a/pages/admin/trust-log.tsx
+++ b/pages/admin/trust-log.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { fetchTrustLog } from "@/utils/trustLog";
+
+export default function TrustLogAdminPage() {
+  const [entries, setEntries] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetchTrustLog().then(setEntries).catch(console.error);
+  }, []);
+
+  return (
+    <div className="max-w-4xl mx-auto p-8">
+      <h1 className="text-2xl font-bold mb-6">🧠 Contributor Trust Audit</h1>
+
+      <table className="w-full border text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">User</th>
+            <th className="p-2 text-left">Prev</th>
+            <th className="p-2 text-left">Next</th>
+            <th className="p-2 text-left">Δ</th>
+            <th className="p-2 text-left">Post</th>
+            <th className="p-2 text-left">Reason</th>
+            <th className="p-2 text-left">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry: any, idx: number) => (
+            <tr key={idx}>
+              <td className="p-2 font-mono">{entry.user}</td>
+              <td className="p-2">{entry.prev}</td>
+              <td className="p-2">{entry.next}</td>
+              <td className={`p-2 ${entry.delta >= 0 ? "text-green-600" : "text-red-600"}`}>
+                {entry.delta >= 0 ? "+" : ""}
+                {entry.delta}
+              </td>
+              <td className="p-2">
+                <a
+                  href={`/post/${entry.postHash}`}
+                  target="_blank"
+                  className="text-blue-600 underline"
+                >
+                  view ↗
+                </a>
+              </td>
+              <td className="p-2">{entry.reason}</td>
+              <td className="p-2 text-xs text-gray-600">
+                {new Date(entry.timestamp).toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/utils/trustLog.ts
+++ b/utils/trustLog.ts
@@ -1,0 +1,22 @@
+export async function fetchTrustLog() {
+  return [
+    {
+      user: "0xAbc...",
+      prev: 68,
+      next: 74,
+      delta: 6,
+      postHash: "QmXYZ...",
+      reason: "strong retrn engagement",
+      timestamp: Date.now() - 20000,
+    },
+    {
+      user: "0xDead...",
+      prev: 91,
+      next: 86,
+      delta: -5,
+      postHash: "QmDEF...",
+      reason: "flagged and removed",
+      timestamp: Date.now() - 60000,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add admin page for contributor trust audit
- mock out `fetchTrustLog()` utility for now

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npx ts-node test/updateTrustFromEngagement.test.ts`
- `npx ts-node test/BlessBurnTracker.test.ts`
- `npx ts-node test/FlagEscalationAI.test.ts`
- `npx ts-node test/LottoModule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68587426b9a483339e1833cd15fdb1d8