### PR TITLE
Add category-based trust scores

### DIFF
--- a/test/updateTrustFromEngagement.test.ts
+++ b/test/updateTrustFromEngagement.test.ts
@@ -3,9 +3,10 @@ import { trustScoreMap } from '../utils/trustState';
 
 (async () => {
   const user = '0xtrustedalpha...';
-  const before = trustScoreMap[user];
-  await updateTrustScoreFromEngagement(user, 'post1');
-  const after = trustScoreMap[user];
+  const category = 'art';
+  const before = trustScoreMap[user][category];
+  await updateTrustScoreFromEngagement(user, { category }, 'post1');
+  const after = trustScoreMap[user][category];
   if (Number.isNaN(after) || after < 0 || after > 100) {
     throw new Error('Trust score out of bounds');
   }

--- a/utils/trust.ts
+++ b/utils/trust.ts
@@ -1,0 +1,11 @@
+import { trustScoreMap } from './trustState';
+
+export function getTrustScore(address: string, category: string): number {
+  const userMap = trustScoreMap[address.toLowerCase()] || {};
+  return userMap[category.toLowerCase()] ?? 50;
+}
+
+export function getTrustWeight(address: string, category: string): number {
+  const score = getTrustScore(address, category);
+  return score >= 90 ? 1.25 : score >= 70 ? 1.1 : 0.9;
+}

--- a/utils/trustState.ts
+++ b/utils/trustState.ts
@@ -1,4 +1,11 @@
-export const trustScoreMap: Record<string, number> = {
-  "0xtrustedalpha...": 94,
-  "0xbotfarm123...": 22,
+// Per-category trust store. Each user maps to a map of category -> score.
+export const trustScoreMap: Record<string, Record<string, number>> = {
+  "0xtrustedalpha...": {
+    art: 94,
+    politics: 72,
+  },
+  "0xbotfarm123...": {
+    art: 22,
+    politics: 30,
+  },
 };


### PR DESCRIPTION
## Summary
- store trust scores per category
- expose helpers for category-based lookup
- update engagement-based scoring to respect categories
- adjust tests for new trust map

## Testing
- `npx -y ts-node test/updateTrustFromEngagement.test.ts`
- `npx -y ts-node test/BlessBurnTracker.test.ts`
- `npx -y ts-node test/FlagEscalationAI.test.ts`
- `npx -y ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npx -y ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_68587633c2c48333b228ed8fade5288d