### PR TITLE
Expose Trust Map API

### DIFF
--- a/pages/api/trust/[addr].ts
+++ b/pages/api/trust/[addr].ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { trustScoreMap } from "@/utils/trustState";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { addr } = req.query;
+
+  if (!addr || typeof addr !== "string") {
+    return res.status(400).json({ error: "Missing or invalid address." });
+  }
+
+  const trustMap = trustScoreMap[addr.toLowerCase()] || {};
+  return res.status(200).json({ address: addr.toLowerCase(), trust: trustMap });
+}


### PR DESCRIPTION
## Summary
- add `/api/trust/[addr]` endpoint that returns per-category trust scores

## Testing
- `npx ts-node test/updateTrustFromEngagement.test.ts`
- `npx hardhat test` *(fails: cannot install `hardhat` without network access)*
- `npm run lint` in `thisrightnow` *(fails: cannot find ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68587c4b78908333bd855d2c7f563ff4