### PR TITLE
Add Trust Score Audit Trail

### DIFF
--- a/components/TrustAuditTrail.tsx
+++ b/components/TrustAuditTrail.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+
+export default function TrustAuditTrail({ address }: { address: string }) {
+  const [entries, setEntries] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/trust-log/${address}`)
+      .then((res) => res.json())
+      .then(setEntries)
+      .catch(console.error);
+  }, [address]);
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">📊 Trust Score Audit Trail</h1>
+      <table className="w-full text-sm border">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Category</th>
+            <th className="p-2 text-left">Δ</th>
+            <th className="p-2 text-left">From</th>
+            <th className="p-2 text-left">To</th>
+            <th className="p-2 text-left">Reason</th>
+            <th className="p-2 text-left">Post</th>
+            <th className="p-2 text-left">Time</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((e, i) => (
+            <tr key={i}>
+              <td className="p-2">{e.category}</td>
+              <td className={`p-2 ${e.delta >= 0 ? "text-green-600" : "text-red-600"}`}> 
+                {e.delta >= 0 ? "+" : ""}
+                {e.delta}
+              </td>
+              <td className="p-2">{e.prev}</td>
+              <td className="p-2">{e.next}</td>
+              <td className="p-2">{e.reason}</td>
+              <td className="p-2">
+                <a href={`/post/${e.postHash}`} className="text-blue-600 underline">
+                  view ↗
+                </a>
+              </td>
+              <td className="p-2 text-xs text-gray-500">
+                {new Date(e.timestamp).toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/account/[addr].tsx
+++ b/pages/account/[addr].tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 
 function TrustBadge({ category, score }: { category: string; score: number }) {
@@ -42,6 +43,12 @@ export default function AccountTrustPage() {
           <TrustBadge key={category} category={category} score={score as number} />
         ))}
       </div>
+      <Link
+        href={`/account/${addr}/trust`}
+        className="text-blue-600 underline text-sm mt-2 block"
+      >
+        View trust score history →
+      </Link>
     </div>
   );
 }

--- a/pages/account/[addr]/trust.tsx
+++ b/pages/account/[addr]/trust.tsx
@@ -1,0 +1,11 @@
+import { useRouter } from "next/router";
+import TrustAuditTrail from "../../../components/TrustAuditTrail";
+
+export default function AccountTrustAuditPage() {
+  const router = useRouter();
+  const { addr } = router.query;
+
+  if (!addr || typeof addr !== "string") return <p>Loading...</p>;
+
+  return <TrustAuditTrail address={addr} />;
+}

--- a/pages/api/trust-log/[addr].ts
+++ b/pages/api/trust-log/[addr].ts
@@ -1,0 +1,26 @@
+export default function handler(req, res) {
+  const { addr } = req.query;
+
+  const sample = [
+    {
+      category: "memes",
+      delta: +4,
+      prev: 85,
+      next: 89,
+      reason: "boosted viral retrn",
+      postHash: "QmXYZ...",
+      timestamp: Date.now() - 60000,
+    },
+    {
+      category: "politics",
+      delta: -6,
+      prev: 72,
+      next: 66,
+      reason: "flagged and removed by mod",
+      postHash: "QmABC...",
+      timestamp: Date.now() - 360000,
+    },
+  ];
+
+  res.status(200).json(sample);
+}


### PR DESCRIPTION
## Summary
- add TrustAuditTrail component for per-address trust log
- expose `/api/trust-log/[addr]` with stub data
- link audit trail from account view
- show TrustAuditTrail page

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68587fd2aeec833390963aa16817783c