### PR TITLE
Add trust-weighted moderation engine

### DIFF
--- a/ai/moderationEngine.ts
+++ b/ai/moderationEngine.ts
@@ -1,0 +1,29 @@
+import { getTrustScore } from "../utils/trust";
+import { getAuditTrail } from "../utils/trustAudit";
+
+export type PostData = { author: string; category: string };
+export type FlagData = { actor: string; severity: number };
+
+export async function assessModeration(post: PostData, flags: FlagData[]) {
+  let score = 0;
+  const category = post.category;
+
+  for (const flag of flags) {
+    const trust = getTrustScore(flag.actor, category);
+    const weight = trust >= 90 ? 1.5 : trust >= 70 ? 1.2 : 1;
+    score += flag.severity * weight;
+  }
+
+  // 🕵️ Look for mod actions or appeals in the audit trail
+  const audit = await getAuditTrail(post.author, category);
+  const recentPositives = audit.filter((a) => a.delta > 0).length;
+  const recentNegatives = audit.filter((a) => a.delta < 0).length;
+
+  if (recentPositives > recentNegatives) {
+    score *= 0.9; // more lenient
+  } else {
+    score *= 1.1; // stricter
+  }
+
+  return score >= 5 ? "ESCALATE" : "ALLOW";
+}

--- a/test/moderationEngine.test.ts
+++ b/test/moderationEngine.test.ts
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import { assessModeration, PostData, FlagData } from '../ai/moderationEngine';
+
+(async () => {
+  const post: PostData = { author: '0xtrustedalpha...', category: 'politics' };
+  const flags: FlagData[] = [
+    { actor: '0xbotfarm123...', severity: 3 },
+    { actor: '0xtrustedalpha...', severity: 2 },
+  ];
+  const result = await assessModeration(post, flags);
+  assert.equal(result, 'ESCALATE');
+  console.log('✅ moderationEngine trust-weighted test passed');
+})();

--- a/utils/trustAudit.ts
+++ b/utils/trustAudit.ts
@@ -1,0 +1,37 @@
+export type AuditEntry = {
+  category: string;
+  delta: number;
+  prev: number;
+  next: number;
+  reason: string;
+  postHash: string;
+  timestamp: number;
+};
+
+const auditLog: Record<string, AuditEntry[]> = {
+  "0xtrustedalpha...": [
+    {
+      category: "politics",
+      delta: 2,
+      prev: 70,
+      next: 72,
+      reason: "accurate flag",
+      postHash: "Qm123...",
+      timestamp: Date.now() - 200000,
+    },
+    {
+      category: "politics",
+      delta: -1,
+      prev: 72,
+      next: 71,
+      reason: "incorrect appeal",
+      postHash: "Qm456...",
+      timestamp: Date.now() - 400000,
+    },
+  ],
+};
+
+export async function getAuditTrail(addr: string, category: string): Promise<AuditEntry[]> {
+  const entries = auditLog[addr.toLowerCase()] || [];
+  return entries.filter((e) => e.category.toLowerCase() === category.toLowerCase());
+}


### PR DESCRIPTION
## Summary
- add `assessModeration` in `ai/moderationEngine.ts`
- provide sample audit trail lookup
- test moderation scoring logic

## Testing
- `npx ts-node test/BlessBurnTracker.test.ts`
- `npx ts-node test/FlagEscalationAI.test.ts`
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npx ts-node test/updateTrustFromEngagement.test.ts`
- `npx ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*
- `npx ts-node test/moderationEngine.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6858827cc3848333803c30dad263bc4a