### PR TITLE
Add moderation summary notifier

### DIFF
--- a/scripts/moderationSummaryNotifier.ts
+++ b/scripts/moderationSummaryNotifier.ts
@@ -1,0 +1,47 @@
+import { fetchFlaggedPosts, getTrustScore, getAuditTrail } from "../utils/modTools";
+import { sendModAlert } from "../utils/notifyMods";
+import { fetchPost } from "../indexer/utils/fetchPost";
+
+export async function runModerationNotifier() {
+  const flagged = await fetchFlaggedPosts();
+
+  for (const { postHash, flags } of flagged) {
+    const post = await fetchPost(postHash);
+    const category = post.category;
+
+    let score = 0;
+    const trustReport: any[] = [];
+
+    for (const flag of flags) {
+      const trust = getTrustScore(flag.actor, category);
+      trustReport.push({ actor: flag.actor, trust, source: flag.source });
+      score += flag.severity * (trust / 100);
+    }
+
+    const audit = await getAuditTrail(post.author, category);
+    const recentNegative = audit.filter((a) => a.delta < 0).length;
+
+    const finalScore = score * (recentNegative > 2 ? 1.2 : 1);
+    const decision = finalScore >= 5 ? "ESCALATE" : "ALLOW";
+
+    if (decision === "ESCALATE") {
+      await sendModAlert({
+        postHash,
+        author: post.author,
+        score: finalScore.toFixed(2),
+        category,
+        trustReport,
+        auditTrail: audit.slice(-5),
+        contentPreview: post.content.slice(0, 240),
+        link: `https://thisrightnow.com/post/${postHash}`,
+      });
+    }
+  }
+}
+
+if (require.main === module) {
+  runModerationNotifier().catch((err) => {
+    console.error("❌ Error in moderation notifier:", err);
+    process.exit(1);
+  });
+}

--- a/utils/modTools.ts
+++ b/utils/modTools.ts
@@ -1,0 +1,25 @@
+import { getTrustScore } from "./trust";
+import { getAuditTrail } from "./trustAudit";
+
+export type Flag = { actor: string; severity: number; source: string };
+export type FlaggedPost = { postHash: string; flags: Flag[] };
+
+export async function fetchFlaggedPosts(): Promise<FlaggedPost[]> {
+  return [
+    {
+      postHash: "QmABC...",
+      flags: [
+        { actor: "0xFlagger1", severity: 3, source: "human" },
+        { actor: "0xBot42", severity: 1, source: "bot" },
+      ],
+    },
+    {
+      postHash: "QmDEF...",
+      flags: [
+        { actor: "0xFlagger2", severity: 2, source: "human" },
+      ],
+    },
+  ];
+}
+
+export { getTrustScore, getAuditTrail };

--- a/utils/notifyMods.ts
+++ b/utils/notifyMods.ts
@@ -1,0 +1,4 @@
+export async function sendModAlert(data: any) {
+  console.log("\uD83D\uDEA8 MOD ALERT:");
+  console.log(JSON.stringify(data, null, 2));
+}


### PR DESCRIPTION
## Summary
- implement `runModerationNotifier` script to alert moderators
- add placeholder moderation utilities
- add console-based mod alert notifier

## Testing
- `npx -y ts-node test/FlagEscalationAI.test.ts`
- `npx -y ts-node test/BlessBurnTracker.test.ts`
- `npx -y ts-node test/moderationEngine.test.ts`
- `npx -y ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npx -y ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*
- `npx -y ts-node test/updateTrustFromEngagement.test.ts`
- `npm test` in `ado-core` *(fails: Hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685883f9fac483338ee0ab9f4fa26a85