### PR TITLE
Add moderator alerts dashboard

### DIFF
--- a/pages/admin/mod-alerts.tsx
+++ b/pages/admin/mod-alerts.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+
+export default function ModAlertsPage() {
+  const [alerts, setAlerts] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/mod-alerts")
+      .then((res) => res.json())
+      .then(setAlerts);
+  }, []);
+
+  const handleDecision = async (hash: string, decision: string) => {
+    await fetch(`/api/mod-alerts/resolve`, {
+      method: "POST",
+      body: JSON.stringify({ hash, decision }),
+      headers: { "Content-Type": "application/json" },
+    });
+    setAlerts((a) => a.filter((x) => x.postHash !== hash));
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">🚨 AI-Flagged Posts</h1>
+      {alerts.map((a, i) => (
+        <div key={i} className="bg-white border p-4 rounded mb-4 shadow-sm">
+          <p className="text-sm text-gray-500 mb-1">{new Date(a.timestamp).toLocaleString()}</p>
+          <p><strong>Post:</strong> <a href={`/post/${a.postHash}`} className="text-blue-600 underline">{a.postHash.slice(0, 10)}...</a></p>
+          <p><strong>Category:</strong> {a.category}</p>
+          <p><strong>Author:</strong> {a.author}</p>
+          <p><strong>Score:</strong> <span className="text-red-600 font-bold">{a.score}</span></p>
+          <p className="mt-2"><strong>Preview:</strong> {a.contentPreview}</p>
+          
+          <div className="mt-4">
+            <h3 className="font-semibold text-sm">Flaggers:</h3>
+            <ul className="text-sm text-gray-700 pl-4 list-disc">
+              {a.trustReport.map((t: any, idx: number) => (
+                <li key={idx}>
+                  {t.actor} — {t.trust} trust ({t.source})
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="mt-4">
+            <h3 className="font-semibold text-sm">Recent Audit Trail:</h3>
+            <ul className="text-xs text-gray-600 pl-4 list-disc">
+              {a.auditTrail.map((e: any, idx: number) => (
+                <li key={idx}>
+                  Δ{e.delta}: {e.reason} — <a href={`/post/${e.postHash}`} className="text-blue-500 underline">view</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="mt-4 flex gap-3">
+            <button
+              onClick={() => handleDecision(a.postHash, "approve")}
+              className="bg-green-600 text-white px-4 py-1 rounded"
+            >
+              ✅ Approve
+            </button>
+            <button
+              onClick={() => handleDecision(a.postHash, "dismiss")}
+              className="bg-gray-400 text-white px-4 py-1 rounded"
+            >
+              ❌ Dismiss
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/pages/api/mod-alerts/index.ts
+++ b/pages/api/mod-alerts/index.ts
@@ -1,0 +1,6 @@
+import { loadAlertsFromStorageOrIPFS } from "@/utils/modAlerts";
+
+export default async function handler(req, res) {
+  const alerts = await loadAlertsFromStorageOrIPFS();
+  res.status(200).json(alerts);
+}

--- a/pages/api/mod-alerts/resolve.ts
+++ b/pages/api/mod-alerts/resolve.ts
@@ -1,0 +1,7 @@
+import { recordModeratorDecision } from "@/utils/modAlerts";
+
+export default async function handler(req, res) {
+  const { hash, decision } = JSON.parse(req.body);
+  await recordModeratorDecision(hash, decision);
+  res.status(200).json({ ok: true });
+}

--- a/utils/modAlerts.ts
+++ b/utils/modAlerts.ts
@@ -1,0 +1,49 @@
+export type ModAlert = {
+  timestamp: number;
+  postHash: string;
+  category: string;
+  author: string;
+  score: number;
+  contentPreview: string;
+  trustReport: { actor: string; trust: number; source: string }[];
+  auditTrail: { delta: number; reason: string; postHash: string }[];
+};
+
+export async function loadAlertsFromStorageOrIPFS(): Promise<ModAlert[]> {
+  return [
+    {
+      timestamp: Date.now() - 15000,
+      postHash: "QmABC123...",
+      category: "politics",
+      author: "0xFlagged1",
+      score: 6.8,
+      contentPreview: "Lorem ipsum dolor sit amet...",
+      trustReport: [
+        { actor: "0xmod123...", trust: 92, source: "human" },
+        { actor: "0xbot456...", trust: 25, source: "bot" },
+      ],
+      auditTrail: [
+        { delta: -4, reason: "prior removal", postHash: "QmPrev1..." },
+        { delta: 2, reason: "appeal granted", postHash: "QmPrev2..." },
+      ],
+    },
+    {
+      timestamp: Date.now() - 30000,
+      postHash: "QmDEF456...",
+      category: "art",
+      author: "0xFlagged2",
+      score: 5.4,
+      contentPreview: "Another questionable post...",
+      trustReport: [
+        { actor: "0xalpha...", trust: 88, source: "human" },
+      ],
+      auditTrail: [
+        { delta: -2, reason: "spam warning", postHash: "QmPrev3..." },
+      ],
+    },
+  ];
+}
+
+export async function recordModeratorDecision(hash: string, decision: string): Promise<void> {
+  console.log(`moderator decision for ${hash}: ${decision}`);
+}


### PR DESCRIPTION
## Summary
- introduce moderation dashboard at `/admin/mod-alerts`
- API stubs to load alerts and resolve moderation actions
- add sample mod-alert utilities

## Testing
- `npx hardhat test` *(fails: needs hardhat install)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: needs ts-node install)*
- `npm run lint` in `thisrightnow` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6858876412648333887e421404e07322