### PR TITLE
Add moderator reputation dashboard

### DIFF
--- a/pages/admin/mod-rep.tsx
+++ b/pages/admin/mod-rep.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+export default function ModRepPage() {
+  const [mods, setMods] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/mods/rep")
+      .then((res) => res.json())
+      .then(setMods);
+  }, []);
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">🧑‍⚖️ Moderator Reputation</h1>
+      <table className="w-full border text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Address</th>
+            <th className="p-2">Approvals</th>
+            <th className="p-2">Dismissals</th>
+            <th className="p-2">Appeal Reversals</th>
+            <th className="p-2">Net Trust</th>
+          </tr>
+        </thead>
+        <tbody>
+          {mods.map((mod) => (
+            <tr key={mod.address} className="border-t">
+              <td className="p-2 font-mono text-blue-700">{mod.address}</td>
+              <td className="p-2 text-center">{mod.approvals}</td>
+              <td className="p-2 text-center">{mod.dismissals}</td>
+              <td className="p-2 text-center text-red-500">{mod.appealReversals}</td>
+              <td className="p-2 text-center font-bold">{mod.netTrust}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/api/mods/rep.ts
+++ b/pages/api/mods/rep.ts
@@ -1,0 +1,18 @@
+import { loadModAuditTrail } from "@/utils/modReputation";
+
+export default async function handler(req, res) {
+  const data = await loadModAuditTrail();
+
+  const result = data.reduce((acc, entry) => {
+    const { actor, delta, reason } = entry;
+    if (!acc[actor]) acc[actor] = { approvals: 0, dismissals: 0, appealReversals: 0, netTrust: 0 };
+    if (reason === "mod_approval") acc[actor].approvals++;
+    if (reason === "mod_dismissal") acc[actor].dismissals++;
+    if (reason === "appeal_reversal") acc[actor].appealReversals++;
+    acc[actor].netTrust += delta;
+    return acc;
+  }, {} as Record<string, { approvals: number; dismissals: number; appealReversals: number; netTrust: number }>);
+
+  const mods = Object.entries(result).map(([address, stats]) => ({ address, ...stats }));
+  res.status(200).json(mods);
+}

--- a/utils/modReputation.ts
+++ b/utils/modReputation.ts
@@ -1,0 +1,15 @@
+export type ModAuditEntry = {
+  actor: string;
+  delta: number;
+  reason: string;
+  timestamp?: number;
+};
+
+export async function loadModAuditTrail(): Promise<ModAuditEntry[]> {
+  return [
+    { actor: "0xModAlpha...", delta: 2, reason: "mod_approval", timestamp: Date.now() - 200000 },
+    { actor: "0xModAlpha...", delta: -1, reason: "appeal_reversal", timestamp: Date.now() - 150000 },
+    { actor: "0xModBeta...", delta: -2, reason: "mod_dismissal", timestamp: Date.now() - 100000 },
+    { actor: "0xModGamma...", delta: 3, reason: "mod_approval", timestamp: Date.now() - 50000 },
+  ];
+}


### PR DESCRIPTION
## Summary
- show mod reputation table at `/admin/mod-rep`
- provide `/api/mods/rep` endpoint
- stub out mod reputation data loader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68588ea44c0c83338798843f3291bed7