### PR TITLE
Add CreateAppeal component for moderation

### DIFF
--- a/components/CreateAppeal.tsx
+++ b/components/CreateAppeal.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { submitAppeal } from "@/utils/moderation";
+
+export default function CreateAppeal({ postHash, onSubmitted }: { postHash: string; onSubmitted: () => void }) {
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await submitAppeal(postHash, reason);
+      setSubmitted(true);
+      onSubmitted();
+    } catch (err) {
+      alert("Error submitting appeal");
+      console.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (submitted) return <p className="text-green-600 mt-4">✅ Appeal submitted successfully.</p>;
+
+  return (
+    <div className="mt-6 p-4 border rounded bg-gray-50">
+      <h3 className="font-bold mb-2">📢 Submit Appeal</h3>
+      <textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        rows={4}
+        placeholder="Explain why this moderation decision was incorrect..."
+        className="w-full p-2 border rounded"
+      />
+      <button
+        onClick={handleSubmit}
+        disabled={submitting || reason.length < 10}
+        className="mt-2 bg-blue-600 text-white px-4 py-1 rounded disabled:opacity-50"
+      >
+        {submitting ? "Submitting..." : "Submit Appeal"}
+      </button>
+    </div>
+  );
+}

--- a/pages/post/[hash]/moderation.tsx
+++ b/pages/post/[hash]/moderation.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import CreateAppeal from '@/components/CreateAppeal';
 
 export default function PostModerationPage() {
   const { query } = useRouter();
@@ -70,6 +71,10 @@ export default function PostModerationPage() {
             {data.appeal.result === 'success' ? '✅ Appeal upheld' : '❌ Appeal denied'} – Reason: {data.appeal.reason}
           </p>
         </>
+      )}
+
+      {!data.appeal && (
+        <CreateAppeal postHash={hash as string} onSubmitted={() => window.location.reload()} />
       )}
     </div>
   );

--- a/thisrightnow/src/abi/ModerationLog.json
+++ b/thisrightnow/src/abi/ModerationLog.json
@@ -1,0 +1,22 @@
+[
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "internalType": "string", "name": "cid", "type": "string" }
+    ],
+    "name": "submitAppeal",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "postHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "submitter", "type": "address" },
+      { "indexed": false, "internalType": "string", "name": "cid", "type": "string" }
+    ],
+    "name": "AppealSubmitted",
+    "type": "event"
+  }
+]

--- a/utils/moderation.ts
+++ b/utils/moderation.ts
@@ -1,3 +1,7 @@
+import ModerationLogABI from '@/abi/ModerationLog.json';
+import { uploadToIPFS } from '@/utils/ipfs';
+import { loadContract } from '@/utils/contract';
+
 export type ModerationOutcome = 'approved' | 'flagged' | 'removed';
 
 export async function getModerationOutcome(_postHash: string): Promise<ModerationOutcome> {
@@ -5,4 +9,14 @@ export async function getModerationOutcome(_postHash: string): Promise<Moderatio
   if (r < 0.1) return 'removed';
   if (r < 0.3) return 'flagged';
   return 'approved';
+}
+
+export async function submitAppeal(postHash: string, reason: string) {
+  const ipfsHash = await uploadToIPFS({ postHash, reason, timestamp: Date.now() });
+
+  const contract = await loadContract('ModerationLog', ModerationLogABI);
+  const tx = await contract.submitAppeal(postHash, ipfsHash);
+  await tx.wait();
+
+  return ipfsHash;
 }


### PR DESCRIPTION
## Summary
- create `CreateAppeal` React component
- show appeal submission UI on post moderation page
- implement `submitAppeal` helper and ABI

## Testing
- `npx -y ts-node test/BlessBurnTracker.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6858997a68408333b6fc9e269599033c