### PR TITLE
Add appeals moderation workflow

### DIFF
--- a/pages/admin/appeals.tsx
+++ b/pages/admin/appeals.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export default function AppealsAdminPage() {
+  const [appeals, setAppeals] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/moderation/appeals/pending")
+      .then((res) => res.json())
+      .then(setAppeals)
+      .catch(console.error);
+  }, []);
+
+  const handleDecision = async (hash: string, approve: boolean) => {
+    const res = await fetch("/api/moderation/appeals/resolve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ postHash: hash, decision: approve ? "approve" : "reject" }),
+    });
+
+    if (res.ok) {
+      setAppeals((prev) => prev.filter((a) => a.postHash !== hash));
+    } else {
+      alert("Error resolving appeal");
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">📜 Pending Appeals</h1>
+      {appeals.length === 0 ? (
+        <p className="text-gray-600">No pending appeals at this time.</p>
+      ) : (
+        <ul className="space-y-6">
+          {appeals.map((a) => (
+            <li key={a.postHash} className="border p-4 rounded bg-white">
+              <p>
+                <b>Post:</b>{" "}
+                <Link href={`/post/${a.postHash}`} className="text-blue-600 underline">
+                  view
+                </Link>{" "}
+                |{" "}
+                <Link href={`/post/${a.postHash}/moderation`} className="text-blue-600 underline">
+                  log
+                </Link>
+              </p>
+              <p>
+                <b>Author:</b>{" "}
+                <Link href={`/account/${a.author}`} className="text-blue-600">
+                  {a.author}
+                </Link>
+              </p>
+              <p>
+                <b>Category:</b> {a.category}
+              </p>
+              <p>
+                <b>Appeal:</b> {a.reason}
+              </p>
+              <div className="mt-3 flex gap-4">
+                <button
+                  onClick={() => handleDecision(a.postHash, true)}
+                  className="bg-green-600 text-white px-4 py-1 rounded"
+                >
+                  ✅ Approve
+                </button>
+                <button
+                  onClick={() => handleDecision(a.postHash, false)}
+                  className="bg-red-600 text-white px-4 py-1 rounded"
+                >
+                  ❌ Reject
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/pages/api/moderation/appeals/pending.ts
+++ b/pages/api/moderation/appeals/pending.ts
@@ -1,0 +1,6 @@
+import { getPendingAppeals } from "@/utils/moderationStore";
+
+export default async function handler(req, res) {
+  const appeals = await getPendingAppeals();
+  res.status(200).json(appeals);
+}

--- a/pages/api/moderation/appeals/resolve.ts
+++ b/pages/api/moderation/appeals/resolve.ts
@@ -1,0 +1,11 @@
+import { resolveAppeal } from "@/utils/moderation";
+
+export default async function handler(req, res) {
+  const { postHash, decision } = req.body;
+  try {
+    await resolveAppeal(postHash, decision);
+    res.status(200).end();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/utils/moderation.ts
+++ b/utils/moderation.ts
@@ -1,6 +1,7 @@
 import ModerationLogABI from '@/abi/ModerationLog.json';
 import { uploadToIPFS } from '@/utils/ipfs';
 import { loadContract } from '@/utils/contract';
+import { resolvePendingAppeal } from './moderationStore';
 
 export type ModerationOutcome = 'approved' | 'flagged' | 'removed';
 
@@ -19,4 +20,8 @@ export async function submitAppeal(postHash: string, reason: string) {
   await tx.wait();
 
   return ipfsHash;
+}
+
+export async function resolveAppeal(postHash: string, decision: 'approve' | 'reject') {
+  await resolvePendingAppeal(postHash, decision);
 }

--- a/utils/moderationLog.ts
+++ b/utils/moderationLog.ts
@@ -1,3 +1,6 @@
+import { logTrustAuditEvent } from './trustAudit';
+import { updateTrustScore, getTrustScore } from './trust';
+
 export type ModerationLogEntry = {
   actor: string;
   target: string;
@@ -10,20 +13,20 @@ export type ModerationLogEntry = {
 
 const moderationLog: ModerationLogEntry[] = [
   {
-    actor: "0xModAlpha...",
-    target: "0xFlagged1",
-    postHash: "QmABC123...",
-    reason: "post_removed",
-    category: "politics",
+    actor: '0xModAlpha...',
+    target: '0xFlagged1',
+    postHash: 'QmABC123...',
+    reason: 'post_removed',
+    category: 'politics',
     delta: -5,
     timestamp: Date.now() - 60000,
   },
   {
-    actor: "0xModBeta...",
-    target: "0xFlagged2",
-    postHash: "QmDEF456...",
-    reason: "appeal_granted",
-    category: "art",
+    actor: '0xModBeta...',
+    target: '0xFlagged2',
+    postHash: 'QmDEF456...',
+    reason: 'appeal_granted',
+    category: 'art',
     delta: 2,
     timestamp: Date.now() - 120000,
   },
@@ -31,4 +34,36 @@ const moderationLog: ModerationLogEntry[] = [
 
 export async function loadTrustAuditTrail(): Promise<ModerationLogEntry[]> {
   return moderationLog;
+}
+
+export async function recordAppealResolution(
+  postHash: string,
+  outcome: 'appeal_granted' | 'appeal_denied',
+  author: string,
+  category: string,
+): Promise<void> {
+  const delta = outcome === 'appeal_granted' ? 1 : -1;
+  moderationLog.push({
+    actor: 'appeals_system',
+    target: author,
+    postHash,
+    reason: outcome,
+    category,
+    delta,
+    timestamp: Date.now(),
+  });
+
+  const prev = getTrustScore(author, category);
+  const next = Math.max(0, Math.min(100, prev + delta));
+  await logTrustAuditEvent({
+    actor: author,
+    category,
+    postHash,
+    delta,
+    reason: outcome,
+    timestamp: Date.now(),
+    prev,
+    next,
+  });
+  updateTrustScore(author, category, delta);
 }

--- a/utils/moderationStore.ts
+++ b/utils/moderationStore.ts
@@ -1,0 +1,45 @@
+import { recordAppealResolution } from "./moderationLog";
+
+export type AppealEntry = {
+  postHash: string;
+  author: string;
+  category: string;
+  reason: string;
+  timestamp: number;
+};
+
+const pendingAppeals: AppealEntry[] = [
+  {
+    postHash: "QmAppealAlpha...",
+    author: "0xUserAlpha...",
+    category: "politics",
+    reason: "This moderation was unfair",
+    timestamp: Date.now() - 45000,
+  },
+  {
+    postHash: "QmAppealBeta...",
+    author: "0xUserBeta...",
+    category: "art",
+    reason: "Removal was a mistake",
+    timestamp: Date.now() - 120000,
+  },
+];
+
+export async function getPendingAppeals(): Promise<AppealEntry[]> {
+  return pendingAppeals;
+}
+
+export async function resolvePendingAppeal(
+  postHash: string,
+  decision: "approve" | "reject",
+): Promise<void> {
+  const idx = pendingAppeals.findIndex((a) => a.postHash === postHash);
+  if (idx === -1) throw new Error("Appeal not found");
+  const appeal = pendingAppeals.splice(idx, 1)[0];
+  await recordAppealResolution(
+    appeal.postHash,
+    decision === "approve" ? "appeal_granted" : "appeal_denied",
+    appeal.author,
+    appeal.category,
+  );
+}


### PR DESCRIPTION
## Summary
- implement new admin appeals page for moderators
- expose API routes for listing and resolving appeals
- track appeals in a simple store
- log trust updates on appeal resolution

## Testing
- `npx hardhat test` *(fails: Hardhat not installed)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: ts-node not installed)*
- `npm run lint` in `thisrightnow/` *(fails: missing ESLint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68589e47e5e08333bfdc912037516f71