### PR TITLE
Add appeal influence analytics page

### DIFF
--- a/pages/analytics/appeal-champions.tsx
+++ b/pages/analytics/appeal-champions.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+export default function AppealChampionsPage() {
+  const [champions, setChampions] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch("/api/moderation/analytics/champions")
+      .then((res) => res.json())
+      .then(setChampions);
+  }, []);
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">🏛️ Appeal Influence Dashboard</h1>
+      <p className="text-gray-600 mb-6">Who’s actually shifting decisions — and earning trust doing it.</p>
+
+      <table className="w-full text-sm border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="p-2 border">User</th>
+            <th className="p-2 border">Appeals Filed</th>
+            <th className="p-2 border">Approved</th>
+            <th className="p-2 border">Win Rate</th>
+            <th className="p-2 border">Top Category</th>
+            <th className="p-2 border">Trust Gain</th>
+          </tr>
+        </thead>
+        <tbody>
+          {champions.map((user) => (
+            <tr key={user.address}>
+              <td className="p-2 border">
+                <Link href={`/account/${user.address}`} className="text-blue-600">
+                  {user.name || user.address.slice(0, 10)}
+                </Link>
+              </td>
+              <td className="p-2 border">{user.appeals}</td>
+              <td className="p-2 border">{user.approved}</td>
+              <td className="p-2 border">{((user.approved / user.appeals) * 100).toFixed(1)}%</td>
+              <td className="p-2 border">{user.topCategory}</td>
+              <td className="p-2 border">{user.trustChange > 0 ? `+${user.trustChange}` : user.trustChange}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/pages/api/moderation/analytics/champions.ts
+++ b/pages/api/moderation/analytics/champions.ts
@@ -1,0 +1,28 @@
+export default function handler(req, res) {
+  res.json([
+    {
+      address: "0xF00...123",
+      name: "FreedomMax",
+      appeals: 12,
+      approved: 9,
+      topCategory: "censorship",
+      trustChange: 14,
+    },
+    {
+      address: "0xB33...abc",
+      name: null,
+      appeals: 8,
+      approved: 5,
+      topCategory: "health",
+      trustChange: 8,
+    },
+    {
+      address: "0xDEAD...BEEF",
+      name: "RebelNode",
+      appeals: 10,
+      approved: 2,
+      topCategory: "politics",
+      trustChange: -1,
+    },
+  ]);
+}


### PR DESCRIPTION
## Summary
- add analytics page to showcase contributors whose appeals changed moderation
- provide mock API endpoint

## Testing
- `npx hardhat test`
- `npx ts-node ../test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858a2e1bac48333a33e027c409675c0