### PR TITLE
Add category trust display to PostCard

### DIFF
--- a/thisrightnow/src/components/Tooltip.tsx
+++ b/thisrightnow/src/components/Tooltip.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react";
+
+export default function Tooltip({ content, children }: { content: string; children: ReactNode }) {
+  return (
+    <span className="relative group">
+      {children}
+      <span className="pointer-events-none absolute z-10 hidden group-hover:block bg-gray-700 text-white text-xs py-1 px-2 rounded -translate-x-1/2 left-1/2 bottom-full mb-1 whitespace-nowrap">
+        {content}
+      </span>
+    </span>
+  );
+}

--- a/thisrightnow/src/utils/TrustScoreEngine.ts
+++ b/thisrightnow/src/utils/TrustScoreEngine.ts
@@ -1,0 +1,7 @@
+import { fetchTrustScore } from "./fetchTrustScore";
+
+// Simplified wrapper that could later be expanded to include category logic
+export async function getTrustScore(category: string, address: string): Promise<number> {
+  // Category parameter reserved for future use
+  return fetchTrustScore(address);
+}


### PR DESCRIPTION
## Summary
- create simple Tooltip component for hover text
- add TrustScoreEngine helper
- show category and trust score in PostCard using Tooltip

## Testing
- `npx hardhat test` *(fails: needs hardhat package)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: needs ts-node package)*
- `npm run lint` in `thisrightnow` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6858abc85c8083338badc7787f437660