### PR TITLE
Add RetrnWeightOracle contract

### DIFF
--- a/ado-core/contracts/RetrnWeightOracle.sol
+++ b/ado-core/contracts/RetrnWeightOracle.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract RetrnWeightOracle {
+    struct RetrnData {
+        uint256 rawScore;
+        uint256 adjustedScore;
+        address contributor;
+        uint256 timestamp;
+    }
+
+    // retrnHash => RetrnData
+    mapping(bytes32 => RetrnData) public retrns;
+
+    // parentPostHash => retrn hashes
+    mapping(bytes32 => bytes32[]) public retrnsByPost;
+
+    event RetrnScored(bytes32 indexed retrnHash, bytes32 indexed parentHash, address contributor, uint256 rawScore, uint256 adjustedScore);
+
+    function recordRetrnScore(
+        bytes32 retrnHash,
+        bytes32 parentHash,
+        address contributor,
+        uint256 rawScore,
+        uint256 adjustedScore
+    ) external {
+        require(retrns[retrnHash].timestamp == 0, "Retrn already recorded");
+
+        retrns[retrnHash] = RetrnData({
+            rawScore: rawScore,
+            adjustedScore: adjustedScore,
+            contributor: contributor,
+            timestamp: block.timestamp
+        });
+
+        retrnsByPost[parentHash].push(retrnHash);
+
+        emit RetrnScored(retrnHash, parentHash, contributor, rawScore, adjustedScore);
+    }
+
+    function getRetrnScore(bytes32 retrnHash) external view returns (uint256 rawScore, uint256 adjustedScore) {
+        RetrnData memory data = retrns[retrnHash];
+        return (data.rawScore, data.adjustedScore);
+    }
+
+    function getRetrnsByPost(bytes32 parentHash) external view returns (bytes32[] memory) {
+        return retrnsByPost[parentHash];
+    }
+
+    function getRetrnMeta(bytes32 retrnHash) external view returns (address contributor, uint256 timestamp) {
+        RetrnData memory data = retrns[retrnHash];
+        return (data.contributor, data.timestamp);
+    }
+}

--- a/ado-core/test/RetrnWeightOracle.test.ts
+++ b/ado-core/test/RetrnWeightOracle.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("RetrnWeightOracle", function () {
+  it("records and retrieves retrn scores", async () => {
+    const [user] = await ethers.getSigners();
+    const Oracle = await ethers.getContractFactory("RetrnWeightOracle");
+    const oracle = await Oracle.deploy();
+
+    const parent = ethers.encodeBytes32String("post1");
+    const retrn = ethers.encodeBytes32String("ret1");
+
+    await oracle.recordRetrnScore(retrn, parent, user.address, 10, 7);
+
+    const scores = await oracle.getRetrnScore(retrn);
+    expect(scores.rawScore).to.equal(10);
+    expect(scores.adjustedScore).to.equal(7);
+
+    const meta = await oracle.getRetrnMeta(retrn);
+    expect(meta.contributor).to.equal(user.address);
+    expect(meta.timestamp).to.be.gt(0);
+
+    const list = await oracle.getRetrnsByPost(parent);
+    expect(list.length).to.equal(1);
+    expect(list[0]).to.equal(retrn);
+  });
+
+  it("reverts on duplicate records", async () => {
+    const [user] = await ethers.getSigners();
+    const Oracle = await ethers.getContractFactory("RetrnWeightOracle");
+    const oracle = await Oracle.deploy();
+
+    const parent = ethers.encodeBytes32String("post1");
+    const retrn = ethers.encodeBytes32String("ret1");
+
+    await oracle.recordRetrnScore(retrn, parent, user.address, 5, 3);
+    await expect(
+      oracle.recordRetrnScore(retrn, parent, user.address, 5, 3)
+    ).to.be.revertedWith("Retrn already recorded");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `RetrnWeightOracle` solidity contract to track weighted retrn scores
- add tests covering recording, retrieval, and duplicate guard

## Testing
- `cd ado-core && npx hardhat test`

------
https://chatgpt.com/codex/tasks/task_e_6858afc0ba0083338eff1d42edc81284