### PR TITLE
Integrate Retrn weight oracle

### DIFF
--- a/indexer/abis/RetrnWeightOracle.json
+++ b/indexer/abis/RetrnWeightOracle.json
@@ -1,0 +1,197 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "name": "RetrnScored",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnMeta",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnScore",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnsByPost",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordRetrnScore",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "retrns",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "retrnsByPost",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/abi/RetrnWeightOracle.json
+++ b/thisrightnow/src/abi/RetrnWeightOracle.json
@@ -1,0 +1,197 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "name": "RetrnScored",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnMeta",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnScore",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRetrnsByPost",
+    "outputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "",
+        "type": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "retrnHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "parentHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      }
+    ],
+    "name": "recordRetrnScore",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "retrns",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rawScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adjustedScore",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "contributor",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "retrnsByPost",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/thisrightnow/src/utils/submitPost.ts
+++ b/thisrightnow/src/utils/submitPost.ts
@@ -1,6 +1,9 @@
 import ViewIndexABI from "@/abi/ViewIndex.json";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import RetrnWeightOracleABI from "@/abi/RetrnWeightOracle.json";
 import { loadContract } from "./contract";
 import { uploadToIPFS } from "./uploadToIPFS";
+import { getTrustScore } from "./TrustScoreEngine";
 
 export async function submitPost(content: string, tags: string[] = []) {
   const ipfsHash = await uploadToIPFS({
@@ -11,6 +14,42 @@ export async function submitPost(content: string, tags: string[] = []) {
 
   const contract = await loadContract("ViewIndex", ViewIndexABI);
   await (contract as any).registerPost(ipfsHash);
+
+  return ipfsHash;
+}
+
+export async function submitRetrn(
+  content: string,
+  parentHash: string,
+  contributor: string
+) {
+  const ipfsHash = await uploadToIPFS({
+    content,
+    parent: parentHash,
+    author: contributor,
+    timestamp: Date.now(),
+  });
+
+  const retrnIndex = await loadContract("RetrnIndex", RetrnIndexABI);
+  const weightOracle = await loadContract(
+    "RetrnWeightOracle",
+    RetrnWeightOracleABI
+  );
+
+  // 🔎 Assume we already have a category tag (or fallback to "general")
+  const category = "general"; // TODO: Replace with AI tag from IPFS content if available
+  const rawScore = 100;
+  const trustScore = await getTrustScore(category, contributor);
+  const adjustedScore = Math.floor(rawScore * (1 + trustScore / 100));
+
+  await (retrnIndex as any).registerRetrn(parentHash, ipfsHash);
+  await (weightOracle as any).recordRetrnScore(
+    ipfsHash,
+    parentHash,
+    contributor,
+    rawScore,
+    adjustedScore
+  );
 
   return ipfsHash;
 }


### PR DESCRIPTION
## Summary
- wire RetrnWeightOracle into retrn submission flow
- generate ABIs for RetrnWeightOracle

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858b20744288333b847792828ea898a