### PR TITLE
Add more RetrnWeightOracle tests

### DIFF
--- a/ado-core/test/RetrnWeightOracle.test.ts
+++ b/ado-core/test/RetrnWeightOracle.test.ts
@@ -2,40 +2,57 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 describe("RetrnWeightOracle", function () {
-  it("records and retrieves retrn scores", async () => {
-    const [user] = await ethers.getSigners();
+  let oracle: any;
+  let owner: any;
+  let user1: any;
+
+  beforeEach(async () => {
+    [owner, user1] = await ethers.getSigners();
+
     const Oracle = await ethers.getContractFactory("RetrnWeightOracle");
-    const oracle = await Oracle.deploy();
-
-    const parent = ethers.encodeBytes32String("post1");
-    const retrn = ethers.encodeBytes32String("ret1");
-
-    await oracle.recordRetrnScore(retrn, parent, user.address, 10, 7);
-
-    const scores = await oracle.getRetrnScore(retrn);
-    expect(scores.rawScore).to.equal(10);
-    expect(scores.adjustedScore).to.equal(7);
-
-    const meta = await oracle.getRetrnMeta(retrn);
-    expect(meta.contributor).to.equal(user.address);
-    expect(meta.timestamp).to.be.gt(0);
-
-    const list = await oracle.getRetrnsByPost(parent);
-    expect(list.length).to.equal(1);
-    expect(list[0]).to.equal(retrn);
+    oracle = await Oracle.deploy();
+    await oracle.waitForDeployment();
   });
 
-  it("reverts on duplicate records", async () => {
-    const [user] = await ethers.getSigners();
-    const Oracle = await ethers.getContractFactory("RetrnWeightOracle");
-    const oracle = await Oracle.deploy();
+  it("should record a retrn score", async () => {
+    const retrnHash = ethers.id("retrn1");
+    const parentHash = ethers.id("parent1");
+    const rawScore = 100;
+    const adjustedScore = 150;
 
-    const parent = ethers.encodeBytes32String("post1");
-    const retrn = ethers.encodeBytes32String("ret1");
+    await oracle.recordRetrnScore(retrnHash, parentHash, user1.address, rawScore, adjustedScore);
 
-    await oracle.recordRetrnScore(retrn, parent, user.address, 5, 3);
+    const [raw, adjusted] = await oracle.getRetrnScore(retrnHash);
+    expect(raw).to.equal(rawScore);
+    expect(adjusted).to.equal(adjustedScore);
+
+    const [contributor, timestamp] = await oracle.getRetrnMeta(retrnHash);
+    expect(contributor).to.equal(user1.address);
+    expect(timestamp).to.be.gt(0);
+  });
+
+  it("should reject duplicate retrn score", async () => {
+    const retrnHash = ethers.id("dup");
+    const parentHash = ethers.id("dupParent");
+
+    await oracle.recordRetrnScore(retrnHash, parentHash, user1.address, 100, 150);
+
     await expect(
-      oracle.recordRetrnScore(retrn, parent, user.address, 5, 3)
+      oracle.recordRetrnScore(retrnHash, parentHash, user1.address, 100, 150)
     ).to.be.revertedWith("Retrn already recorded");
+  });
+
+  it("should list retrns by parent hash", async () => {
+    const parent = ethers.id("threadRoot");
+
+    const r1 = ethers.id("r1");
+    const r2 = ethers.id("r2");
+
+    await oracle.recordRetrnScore(r1, parent, user1.address, 100, 120);
+    await oracle.recordRetrnScore(r2, parent, user1.address, 80, 100);
+
+    const list = await oracle.getRetrnsByPost(parent);
+    expect(list.length).to.equal(2);
+    expect(list).to.include.members([r1, r2]);
   });
 });


### PR DESCRIPTION
## Summary
- extend `RetrnWeightOracle.test.ts` to cover duplicate rejection and parent list retrieval

## Testing
- `cd ado-core && npx hardhat test test/RetrnWeightOracle.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6858b63c9e8883339282e2fa0b349d09