### PR TITLE
Add trust weighting for earnings

### DIFF
--- a/indexer/applyTrustWeighting.ts
+++ b/indexer/applyTrustWeighting.ts
@@ -1,0 +1,20 @@
+import { getTrustMap } from '../utils/trust';
+
+export async function applyTrustWeighting(earningLogs: any[]) {
+  const adjusted: any[] = [];
+
+  for (const log of earningLogs) {
+    const trustMap = await getTrustMap(log.contributor);
+    const trust = trustMap[log.category ?? 'general'] ?? 0;
+    const multiplier = trust / 100;
+
+    adjusted.push({
+      ...log,
+      originalAmount: log.amount,
+      adjustedAmount: Math.floor(log.amount * multiplier),
+      trustScore: trust,
+    });
+  }
+
+  return adjusted;
+}

--- a/test/applyTrustWeighting.test.ts
+++ b/test/applyTrustWeighting.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { applyTrustWeighting } from '../indexer/applyTrustWeighting';
+
+const logs = [
+  { contributor: '0xtrustedalpha...', category: 'art', amount: 100 },
+  { contributor: '0xbotfarm123...', category: 'art', amount: 100 },
+  { contributor: '0xtrustedalpha...', category: 'politics', amount: 100 },
+  { contributor: '0xunknown...', category: 'art', amount: 100 },
+];
+
+(async () => {
+  const result = await applyTrustWeighting(logs);
+  assert.equal(result[0].adjustedAmount, 94);
+  assert.equal(result[1].adjustedAmount, 22);
+  assert.equal(result[2].adjustedAmount, 72);
+  assert.equal(result[3].adjustedAmount, 0);
+  console.log('✅ applyTrustWeighting test passed');
+})();

--- a/utils/trust.ts
+++ b/utils/trust.ts
@@ -10,6 +10,11 @@ export function getTrustWeight(address: string, category: string): number {
   return score >= 90 ? 1.25 : score >= 70 ? 1.1 : 0.9;
 }
 
+export function getTrustMap(address: string): Record<string, number> {
+  const map = trustScoreMap[address.toLowerCase()] || {};
+  return { ...map, general: map.general ?? 50 };
+}
+
 export function setTrustScore(
   address: string,
   category: string,


### PR DESCRIPTION
## Summary
- implement `getTrustMap` util
- add `applyTrustWeighting` function in indexer
- test trust-weighted earnings calculation

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npx ts-node test/applyTrustWeighting.test.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6858c58a4fa08333917746c44abb8c10