### PR TITLE
Connect trust weighting to Merkle builder

### DIFF
--- a/indexer/applyTrustWeighting.ts
+++ b/indexer/applyTrustWeighting.ts
@@ -4,12 +4,14 @@ export async function applyTrustWeighting(earningLogs: any[]) {
   const adjusted: any[] = [];
 
   for (const log of earningLogs) {
-    const trustMap = await getTrustMap(log.contributor);
+    const contributor = log.contributor ?? log.viewer;
+    const trustMap = await getTrustMap(contributor);
     const trust = trustMap[log.category ?? 'general'] ?? 0;
     const multiplier = trust / 100;
 
     adjusted.push({
       ...log,
+      contributor,
       originalAmount: log.amount,
       adjustedAmount: Math.floor(log.amount * multiplier),
       trustScore: trust,

--- a/indexer/buildMerkle.ts
+++ b/indexer/buildMerkle.ts
@@ -2,18 +2,22 @@
 import keccak256 from "keccak256";
 import { MerkleTree } from "merkletreejs";
 import fs from "fs";
+import { applyTrustWeighting } from "./applyTrustWeighting";
 
-export function buildMerkleFromViews(viewData: { viewer: string; amount: number }[]) {
-  const leaves = viewData.map((v) =>
-    keccak256(`${v.viewer.toLowerCase()}-${v.amount}`)
+export async function buildMerkleFromViews(viewData: { viewer: string; amount: number; postHash?: string; category?: string }[]) {
+  const adjusted = await applyTrustWeighting(viewData);
+  const leaves = adjusted.map((v) =>
+    keccak256(`${v.viewer.toLowerCase()}-${v.adjustedAmount}`)
   );
 
   const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
   const root = tree.getHexRoot();
 
   const claims = leaves.map((l, i) => ({
-    viewer: viewData[i].viewer,
-    amount: viewData[i].amount,
+    viewer: adjusted[i].viewer,
+    originalAmount: adjusted[i].originalAmount,
+    amount: adjusted[i].adjustedAmount,
+    postHash: adjusted[i].postHash,
     leaf: `0x${l.toString("hex")}`,
     proof: tree.getHexProof(l),
   }));


### PR DESCRIPTION
## Summary
- apply trust weighting when building view-based Merkle trees
- allow `applyTrustWeighting` to accept logs with `viewer` or `contributor`

## Testing
- `npx -y ts-node test/applyTrustWeighting.test.ts`
- `npx -y ts-node test/BlessBurnTracker.test.ts`
- `npx -y ts-node test/FlagEscalationAI.test.ts`
- `npx -y ts-node test/moderationEngine.test.ts`
- `npx -y ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*
- `npx -y ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npx -y ts-node test/updateTrustFromEngagement.test.ts` *(fails: Cannot find module '@/abi/ModerationLog.json')*

------
https://chatgpt.com/codex/tasks/task_e_6858c8a59eb88333aa953983d7c2eddd