### PR TITLE
Add trust-weighted distribution flow

### DIFF
--- a/ado-core/contracts/MockContributorVault.sol
+++ b/ado-core/contracts/MockContributorVault.sol
@@ -1,24 +1,76 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
 interface ITRNUsageOracle {
     function reportEarning(address user, uint256 amount, bytes32 sourceHash) external;
+    function getTrustScore(address contributor, string memory category) external view returns (uint256);
+    function notifyEarnings(address contributor, uint256 amount) external;
 }
 
+/// @title MockContributorVault
+/// @notice Simple vault used in tests. Supports direct claims and a trust-weighted distribution.
 contract MockContributorVault {
+    // Legacy claim flow used in existing tests
     mapping(address => uint256) public claimable;
+
+    // Trust-weighted distribution state
+    address public owner;
+    IERC20 public trn;
+    ITRNUsageOracle public oracle;
+    address[] public contributors;
+    mapping(address => uint256) public earned;
 
     event Claimed(address indexed user, uint256 amount);
 
+    constructor(address token, address oracleAddr) {
+        owner = msg.sender;
+        trn = IERC20(token);
+        oracle = ITRNUsageOracle(oracleAddr);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    /// @notice Mock function to pre-load claimable amounts
     function mockDistribute(address user, uint256 amount) external {
         claimable[user] += amount;
     }
 
-    function claim(address oracle) external {
+    /// @notice Legacy claim that reports earnings to the oracle
+    function claim(address oracleAddr) external {
         uint256 amount = claimable[msg.sender];
         require(amount > 0, "Nothing to claim");
         claimable[msg.sender] = 0;
         emit Claimed(msg.sender, amount);
-        ITRNUsageOracle(oracle).reportEarning(msg.sender, amount, keccak256("contributor-vault"));
+        ITRNUsageOracle(oracleAddr).reportEarning(msg.sender, amount, keccak256("contributor-vault"));
+    }
+
+    /// @notice Set earned amount for a contributor (used by tests)
+    function setEarned(address contributor, uint256 amount) external onlyOwner {
+        if (earned[contributor] == 0) {
+            contributors.push(contributor);
+        }
+        earned[contributor] = amount;
+    }
+
+    /// @notice Distribute TRN to contributors weighted by their trust score
+    function distribute(string memory category) public onlyOwner {
+        for (uint256 i = 0; i < contributors.length; i++) {
+            address contributor = contributors[i];
+            uint256 base = earned[contributor];
+            if (base == 0) continue;
+
+            uint256 trust = oracle.getTrustScore(contributor, category); // 0-100
+            uint256 adjusted = (base * trust) / 100;
+
+            require(trn.transfer(contributor, adjusted), "Transfer failed");
+            oracle.notifyEarnings(contributor, adjusted);
+            earned[contributor] = 0;
+        }
     }
 }
+

--- a/ado-core/test/ClaimAll.test.ts
+++ b/ado-core/test/ClaimAll.test.ts
@@ -4,13 +4,16 @@ import { MerkleTree } from "merkletreejs";
 import keccak256 from "keccak256";
 
 describe("ClaimAll Flow", () => {
-  let oracle: any, drop: any, investorVault: any, contributorVault: any;
+  let oracle: any, drop: any, investorVault: any, contributorVault: any, token: any;
   let user: any, other: any;
 
   const scale = (n: number) => ethers.parseUnits(n.toString(), 18);
 
   beforeEach(async () => {
     [user, other] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockTRN");
+    token = await Token.deploy();
 
     const Oracle = await ethers.getContractFactory("TRNUsageOracle");
     oracle = await Oracle.deploy();
@@ -19,7 +22,7 @@ describe("ClaimAll Flow", () => {
     investorVault = await InvestorVault.deploy();
 
     const ContributorVault = await ethers.getContractFactory("MockContributorVault");
-    contributorVault = await ContributorVault.deploy();
+    contributorVault = await ContributorVault.deploy(token.target, oracle.target);
 
     const Drop = await ethers.getContractFactory("MerkleDropDistributor");
     drop = await Drop.deploy(oracle.target);

--- a/ado-core/test/ContributorVault.test.ts
+++ b/ado-core/test/ContributorVault.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("ContributorVault trust weighting", function () {
+  let oracle: any;
+  let token: any;
+  let vault: any;
+  let addr1: any;
+  let addr2: any;
+
+  beforeEach(async () => {
+    [addr1, addr2] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory("MockTRN");
+    token = await Token.deploy();
+
+    const Oracle = await ethers.getContractFactory("TRNUsageOracle");
+    oracle = await Oracle.deploy();
+
+    const Vault = await ethers.getContractFactory("MockContributorVault");
+    vault = await Vault.deploy(token.target, oracle.target);
+
+    await token.mint(vault.target, ethers.parseUnits("2000", 0));
+  });
+
+  it("applies trust score to TRN distribution", async () => {
+    await vault.setEarned(addr1.address, 1000);
+    await vault.setEarned(addr2.address, 1000);
+
+    await oracle.setTrustScore(addr1.address, "social", 90);
+    await oracle.setTrustScore(addr2.address, "social", 10);
+
+    await vault.distribute("social");
+
+    const bal1 = await token.balanceOf(addr1.address);
+    const bal2 = await token.balanceOf(addr2.address);
+
+    expect(bal1).to.equal(900);
+    expect(bal2).to.equal(100);
+
+    expect(await oracle.earnedTRN(addr1.address)).to.equal(900);
+  });
+});


### PR DESCRIPTION
## Summary
- upgrade `MockContributorVault` with trust-weighted distribution logic
- extend `TRNUsageOracle` with trust score storage and notifier
- update ClaimAll test for new vault constructor
- add ContributorVault trust-weight test

## Testing
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: ts-node missing)*
- `npm run lint` in `thisrightnow` *(fails: cannot find '@eslint/js')*
- `npx hardhat test` *(fails: hardhat not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858ccd133988333a22fdb7e2fad62b5