### PR TITLE
Implement daily earnings aggregator

### DIFF
--- a/indexer/emitDailyMerkle.ts
+++ b/indexer/emitDailyMerkle.ts
@@ -4,7 +4,25 @@ import { getVaultEarnings } from './vaultScanner';
 import { getLottoWinners } from './fetchLotto';
 import { applyTrustWeighting } from './applyTrustWeighting';
 import { buildRetrnTree, calcResonanceScore } from './RetrnScoreEngine';
+import { getTrustMap } from '../utils/trust';
 import fs from 'fs';
+
+interface DailyEarnings {
+  [address: string]: {
+    total: number;
+    breakdown: {
+      views: number;
+      retrns: number;
+      blessings: number;
+      vaults: number;
+      lotto: number;
+    };
+    trustMap: {
+      [category: string]: number;
+    };
+    proof?: string[];
+  };
+}
 
 async function getResonanceBonusForPost(postHash: string) {
   const tree = await buildRetrnTree(postHash);
@@ -12,12 +30,25 @@ async function getResonanceBonusForPost(postHash: string) {
   return Math.floor(score); // 1 TRN per resonance point
 }
 
-async function calculateRewards(date: string) {
+function initEntry(addr: string, map: DailyEarnings) {
+  if (!map[addr]) {
+    map[addr] = {
+      total: 0,
+      breakdown: { views: 0, retrns: 0, blessings: 0, vaults: 0, lotto: 0 },
+      trustMap: getTrustMap(addr),
+    };
+  }
+}
+
+async function aggregateEarnings(date: string): Promise<DailyEarnings> {
   const viewData = await getDailyViews(date);
   const vaultData = await getVaultEarnings();
   const lottoData = await getLottoWinners(date);
-  const viewLogs: { viewer: string; amount: number; category: string }[] = [];
 
+  const earnings: DailyEarnings = {};
+
+  // --- Views + Resonance ---
+  const viewLogs: { viewer: string; amount: number; category: string }[] = [];
   for (const [postHash, { viewers }] of Object.entries(viewData)) {
     const resonanceBonus = await getResonanceBonusForPost(postHash);
     const perViewerBonus = Math.floor(
@@ -30,42 +61,59 @@ async function calculateRewards(date: string) {
       viewLogs.push({ viewer, amount: base + bonus, category: 'general' });
     }
   }
-  const adjustedViews = await applyTrustWeighting(viewLogs);
-  const viewMap: Record<string, number> = {};
-  for (const entry of adjustedViews) {
-    if (!viewMap[entry.viewer]) viewMap[entry.viewer] = 0;
-    viewMap[entry.viewer] += entry.adjustedAmount;
+
+  const adjusted = await applyTrustWeighting(viewLogs);
+  for (const entry of adjusted) {
+    initEntry(entry.viewer, earnings);
+    earnings[entry.viewer].breakdown.views += entry.adjustedAmount;
+    earnings[entry.viewer].total += entry.adjustedAmount;
   }
 
-  lottoData.forEach(({ addr, amount }) => {
-    if (!viewMap[addr]) viewMap[addr] = 0;
-    viewMap[addr] += amount;
-  });
-
-  for (const [addr, vaultAmount] of Object.entries(vaultData)) {
-    if (!viewMap[addr]) viewMap[addr] = 0;
-    viewMap[addr] += vaultAmount;
+  // --- Lotto ---
+  for (const { addr, amount, category } of lottoData) {
+    initEntry(addr, earnings);
+    earnings[addr].breakdown.lotto += amount;
+    earnings[addr].total += amount;
+    earnings[addr].trustMap[category] = earnings[addr].trustMap[category] ?? 0;
   }
 
-  return viewMap;
+  // --- Vault payouts ---
+  for (const [addr, amount] of Object.entries(vaultData)) {
+    initEntry(addr, earnings);
+    earnings[addr].breakdown.vaults += amount;
+    earnings[addr].total += amount;
+  }
+
+  return earnings;
 }
 
-export async function emitMerkleDrop(date = new Date().toISOString().split('T')[0]) {
-  const rewards = await calculateRewards(date);
+export async function emitMerkleDrop(
+  date = new Date().toISOString().split('T')[0]
+) {
+  const earnings = await aggregateEarnings(date);
 
-  const entries = Object.entries(rewards).map(([addr, amount]) => ({
+  const entries = Object.entries(earnings).map(([addr, data]) => ({
     address: addr,
-    amount: BigInt(Math.floor(amount * 1e18)),
+    amount: BigInt(Math.floor(data.total * 1e18)),
   }));
 
-  const merkleData = buildMerkleTree(entries);
+  const merkle = buildMerkleTree(entries);
+
+  for (const [addr, claim] of Object.entries(merkle.claims)) {
+    if (earnings[addr]) earnings[addr].proof = claim.proof;
+  }
 
   fs.writeFileSync(
     `./output/merkle-${date}.json`,
-    JSON.stringify(merkleData, null, 2)
+    JSON.stringify(merkle, null, 2)
   );
+  fs.writeFileSync(
+    `./output/daily-${date}.json`,
+    JSON.stringify(earnings, null, 2)
+  );
+
   console.log(
-    `✅ Merkle drop created for ${date} with ${entries.length} entries.`
+    `✅ Daily earnings + Merkle drop created for ${date} with ${entries.length} entries.`
   );
 }
 


### PR DESCRIPTION
## Summary
- extend `emitDailyMerkle` to aggregate rewards from views, vaults and lotto
- generate a detailed daily earnings object with trust maps
- output both Merkle data and daily totals

## Testing
- `npx --yes ts-node test/applyTrustWeighting.test.ts`
- `npx --yes ts-node test/BlessBurnTracker.test.ts`
- `npx --yes ts-node test/FlagEscalationAI.test.ts`
- `npx --yes ts-node test/moderationEngine.test.ts`
- `npx --yes ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npx --yes ts-node test/LottoModule.test.ts` *(fails: Cannot find module 'ethers')*
- `npx --yes ts-node test/updateTrustFromEngagement.test.ts` *(fails: Cannot find module '@/abi/ModerationLog.json')*

------
https://chatgpt.com/codex/tasks/task_e_6858dbfff1f08333a6fcc0cd4b5d17b2