### PR TITLE
Add view log reader utilities

### DIFF
--- a/indexer/sources/views.ts
+++ b/indexer/sources/views.ts
@@ -1,7 +1,29 @@
+import { getLogsForEvent } from "@/utils/logs";
+import ViewIndexABI from "@/abi/ViewIndex.json";
+import { parseAbiItem } from "viem";
+
+const event = parseAbiItem(
+  "event ViewLogged(address indexed viewer, bytes32 indexed postHash)"
+);
+
 export async function getViewEarnings(): Promise<Record<string, number>> {
-  // TODO: Replace with actual logic to pull trust-weighted view earnings
-  return {
-    "0xViewer1": 12,
-    "0xViewer2": 8
-  };
+  const logs = await getLogsForEvent({
+    contractName: "ViewIndex",
+    abi: ViewIndexABI,
+    event,
+    fromBlock: "latest", // 👈 Replace with actual block range
+  });
+
+  const earnings: Record<string, number> = {};
+
+  for (const log of logs) {
+    const viewer = log.args.viewer as string;
+
+    // Trust-weighted: add your logic here if trust scores are available
+    const points = 1; // default value
+
+    earnings[viewer] = (earnings[viewer] || 0) + points;
+  }
+
+  return earnings;
 }

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -1,0 +1,20 @@
+import { createPublicClient, http } from "viem";
+import { localhost } from "viem/chains";
+
+const addressMap: Record<string, string> = {
+  ViewIndex: process.env.VIEWINDEX_ADDRESS || "0xYourViewIndexAddress",
+};
+
+export function getPublicClient() {
+  const client = createPublicClient({
+    chain: localhost,
+    transport: http(process.env.RPC_URL || "http://localhost:8545"),
+  });
+
+  return {
+    getContractAddress(name: string) {
+      return addressMap[name];
+    },
+    getLogs: client.getLogs,
+  } as const;
+}

--- a/utils/logs.ts
+++ b/utils/logs.ts
@@ -1,0 +1,26 @@
+import { getPublicClient } from "@/utils/client";
+
+export async function getLogsForEvent({
+  contractName,
+  abi,
+  event,
+  fromBlock,
+  toBlock = "latest",
+}: {
+  contractName: string;
+  abi: any;
+  event: any;
+  fromBlock: number | "latest";
+  toBlock?: number | "latest";
+}) {
+  const client = getPublicClient();
+  const address = await client.getContractAddress(contractName);
+
+  return await client.getLogs({
+    address,
+    abi,
+    event,
+    fromBlock,
+    toBlock,
+  });
+}


### PR DESCRIPTION
## Summary
- fetch view logs via `getViewEarnings`
- provide helper to query logs from contracts
- expose `getPublicClient` for viem

## Testing
- `npx ts-node test/BlessBurnTracker.test.ts`
- `npx ts-node test/FlagEscalationAI.test.ts`
- `npx ts-node test/applyTrustWeighting.test.ts`
- `npx ts-node test/moderationEngine.test.ts`
- `npx ts-node test/RetrnScoreEngine.test.ts`
- `npx ts-node test/LottoModule.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6858e319368483338b4362f44244e915