### PR TITLE
Implement trust-weighted view earnings

### DIFF
--- a/indexer/TrustScoreEngine.ts
+++ b/indexer/TrustScoreEngine.ts
@@ -1,5 +1,8 @@
 // Placeholder trust score engine
-export async function getTrustScore(_hash: string): Promise<number> {
+export async function getTrustScore(
+  _addr: string,
+  _category?: string,
+): Promise<number> {
   // In a real implementation this would query on-chain data or analytics.
-  return 1;
+  return 50;
 }

--- a/indexer/sources/views.ts
+++ b/indexer/sources/views.ts
@@ -1,5 +1,6 @@
 import { getLogsForEvent } from "@/utils/logs";
 import ViewIndexABI from "@/abi/ViewIndex.json";
+import { getTrustScore } from "../TrustScoreEngine";
 import { parseAbiItem } from "viem";
 
 const event = parseAbiItem(
@@ -19,10 +20,10 @@ export async function getViewEarnings(): Promise<Record<string, number>> {
   for (const log of logs) {
     const viewer = log.args.viewer as string;
 
-    // Trust-weighted: add your logic here if trust scores are available
-    const points = 1; // default value
+    const trust = await getTrustScore(viewer, "engagement.view"); // 0-100
+    const adjusted = (1 * trust) / 100;
 
-    earnings[viewer] = (earnings[viewer] || 0) + points;
+    earnings[viewer] = (earnings[viewer] || 0) + adjusted;
   }
 
   return earnings;


### PR DESCRIPTION
## Summary
- fetch trust score when calculating view earnings
- allow `getTrustScore` helper to accept category input

## Testing
- `npx ts-node test/applyTrustWeighting.test.ts`
- `npx ts-node test/RetrnScoreEngine.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6858e4cf24f88333a09f8104574c42be