### PR TITLE
Add TrustScoreEngine adapter

### DIFF
--- a/utils/TrustScoreEngine.ts
+++ b/utils/TrustScoreEngine.ts
@@ -1,0 +1,28 @@
+// utils/TrustScoreEngine.ts
+
+/**
+ * Adapter to retrieve a contributor's trust score for a given category.
+ *
+ * @param addr Ethereum address of contributor
+ * @param category Trust category string (e.g., "engagement.view", "post.tech", etc.)
+ * @returns Trust score as integer (0–100)
+ */
+export async function getTrustScore(addr: string, category: string): Promise<number> {
+  // 🔄 TODO: Replace with real trust store (on-chain, DB, IPFS, etc.)
+
+  // Example: local mock trust map
+  const mockTrust: Record<string, Record<string, number>> = {
+    "0x123...": {
+      "engagement.view": 80,
+      "post.tech": 95,
+    },
+    "0x456...": {
+      "engagement.view": 30,
+    },
+  };
+
+  const userTrust = mockTrust[addr.toLowerCase()];
+  if (!userTrust) return 50; // default neutral trust
+
+  return userTrust[category] ?? 50;
+}


### PR DESCRIPTION
## Summary
- implement `getTrustScore` adapter in `utils/TrustScoreEngine.ts`

## Testing
- `npx tsc --version`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6858e5eedcec833399573547af3362db