### PR TITLE
Implement Retrn earnings logic

### DIFF
--- a/indexer/sources/retrns.ts
+++ b/indexer/sources/retrns.ts
@@ -1,7 +1,36 @@
+import { getLogsForEvent } from "@/utils/logs";
+import RetrnIndexABI from "@/abi/RetrnIndex.json";
+import { parseAbiItem } from "viem";
+import { getTrustScore } from "@/utils/TrustScoreEngine";
+
+const event = parseAbiItem(
+  "event RetrnRegistered(address indexed author, bytes32 indexed parent, bytes32 newHash)"
+);
+
+/**
+ * Retrieve trust-weighted retrn earnings for each author.
+ *
+ * Every RetrnRegistered log gives the author 1 point multiplied by their trust
+ * score percentage. For example a trust score of 80 results in `0.8` earnings.
+ */
 export async function getRetrnEarnings(): Promise<Record<string, number>> {
-  // TODO: Replace with actual logic to pull retrn earnings (trust-weighted)
-  return {
-    "0xContributor1": 15,
-    "0xContributor2": 5
-  };
+  const logs = await getLogsForEvent({
+    contractName: "RetrnIndex",
+    abi: RetrnIndexABI,
+    event,
+    fromBlock: 0, // adjust to the desired indexing start
+  });
+
+  const earnings: Record<string, number> = {};
+
+  for (const log of logs) {
+    const author = log.args.author as string;
+
+    const trust = await getTrustScore(author, "engagement.retrn");
+    const weighted = (1 * trust) / 100;
+
+    earnings[author] = (earnings[author] || 0) + weighted;
+  }
+
+  return earnings;
 }


### PR DESCRIPTION
## Summary
- implement log-based trust-weighted earnings for Retrns
- add retrieval of on-chain logs and trust score weighting

## Testing
- `npx hardhat test`
- `for f in test/*.test.ts; do npx -y ts-node $f; done` *(fails: utils/moderation.ts module imports not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e6c3aae4833385bd2d1ffdb00f96