### PR TITLE
Implement BRN slashing flow

### DIFF
--- a/ado-core/contracts/BurnRegistry.sol
+++ b/ado-core/contracts/BurnRegistry.sol
@@ -5,6 +5,10 @@ pragma solidity ^0.8.24;
 /// @notice Tracks all post-level TRN burns, used for eligibility, moderation, and BRN lifecycle enforcement.
 
 contract BurnRegistry {
+    address public flagEscalator;
+
+    // BRN staked per post (aggregated)
+    mapping(bytes32 => uint256) public brnStaked;
     event BurnRecorded(address indexed user, bytes32 indexed postHash, uint256 amount, uint256 timestamp);
 
     struct BurnEvent {
@@ -18,15 +22,36 @@ contract BurnRegistry {
     // Aggregate burns per user
     mapping(address => uint256) public totalBurned;
 
+    constructor(address _flagEscalator) {
+        flagEscalator = _flagEscalator;
+    }
+
+    function updateEscalator(address _flagEscalator) external {
+        require(flagEscalator == address(0) || msg.sender == flagEscalator, "Locked");
+        flagEscalator = _flagEscalator;
+    }
+
     /// @notice Called when a user burns TRN on a post (e.g. via downvote or retrn)
+    /// @dev Only the FlagEscalator is authorized to log burns.
     function recordBurn(address user, bytes32 postHash, uint256 amount) external {
+        require(msg.sender == flagEscalator, "Only escalator");
         burnHistory[user][postHash].push(BurnEvent({
             amount: amount,
             timestamp: block.timestamp
         }));
 
+        brnStaked[postHash] += amount;
+
         totalBurned[user] += amount;
         emit BurnRecorded(user, postHash, amount, block.timestamp);
+    }
+
+    /// @notice Clears staked BRN for a post (called after slashing)
+    function clearStake(bytes32 postHash) external returns (uint256) {
+        require(msg.sender == flagEscalator, "Only escalator");
+        uint256 amount = brnStaked[postHash];
+        brnStaked[postHash] = 0;
+        return amount;
     }
 
     /// @notice Get total number of burns a user has made on a post

--- a/ado-core/contracts/FlagEscalator.sol
+++ b/ado-core/contracts/FlagEscalator.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./BurnRegistry.sol";
+
+/// @title FlagEscalator
+/// @notice Processes escalated flags and slashes BRN to the DAO treasury when community burn threshold is met.
+contract FlagEscalator {
+    event PostSlashed(bytes32 indexed postHash, uint256 brnAmount, address indexed treasury);
+
+    IERC20 public BRN;
+    BurnRegistry public burnRegistry;
+    address public moderationBot;
+    address public daoTreasury;
+
+    uint256 public constant BURN_THRESHOLD = 10;
+
+    // Track BRN staked per post locally for quick access
+    mapping(bytes32 => uint256) public brnStaked;
+
+    constructor(address _brn, address _burnRegistry, address _daoTreasury, address _moderationBot) {
+        BRN = IERC20(_brn);
+        burnRegistry = BurnRegistry(_burnRegistry);
+        daoTreasury = _daoTreasury;
+        moderationBot = _moderationBot;
+    }
+
+    /// @notice Records a burn event and holds BRN inside this contract
+    function stakeBRN(bytes32 postHash, uint256 amount) external {
+        BRN.transferFrom(msg.sender, address(this), amount);
+        brnStaked[postHash] += amount;
+        burnRegistry.recordBurn(msg.sender, postHash, amount);
+    }
+
+    function getBurnRatio(bytes32 postHash) public view returns (uint256) {
+        return brnStaked[postHash];
+    }
+
+    function pruneContent(bytes32 /*postHash*/) internal {
+        // In real implementation, this would log to ModerationLog
+    }
+
+    /// @notice Called by the moderation bot after AI escalation
+    function processEscalation(bytes32 postHash) external {
+        require(msg.sender == moderationBot, "Only AI/modbot");
+
+        if (getBurnRatio(postHash) >= BURN_THRESHOLD) {
+            pruneContent(postHash);
+
+            uint256 brn = brnStaked[postHash];
+            brnStaked[postHash] = 0;
+
+            BRN.transfer(daoTreasury, brn);
+            burnRegistry.clearStake(postHash);
+
+            emit PostSlashed(postHash, brn, daoTreasury);
+        }
+    }
+}

--- a/ado-core/contracts/MockBRN.sol
+++ b/ado-core/contracts/MockBRN.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @title MockBRN
+/// @notice Simple ERC20 token used to simulate BRN for testing.
+contract MockBRN is ERC20 {
+    constructor() ERC20("Burncoin", "BRN") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/ado-core/test/FlagEscalator.test.ts
+++ b/ado-core/test/FlagEscalator.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("FlagEscalator", function () {
+  it("slashes staked BRN to the DAO when threshold crossed", async () => {
+    const [user, bot, dao] = await ethers.getSigners();
+
+    const BRN = await ethers.getContractFactory("MockBRN");
+    const brn = await BRN.deploy();
+
+    const BurnRegistry = await ethers.getContractFactory("BurnRegistry");
+    const registry = await BurnRegistry.deploy(ethers.ZeroAddress);
+
+    const Escalator = await ethers.getContractFactory("FlagEscalator");
+    const escalator = await Escalator.deploy(brn.target, registry.target, dao.address, bot.address);
+
+    await registry.updateEscalator(escalator.target);
+
+    // user stakes 15 BRN on a post
+    const postHash = ethers.encodeBytes32String("post1");
+    await brn.mint(user.address, 15);
+    await brn.connect(user).approve(escalator.target, 15);
+    await escalator.connect(user).stakeBRN(postHash, 15);
+
+    // before escalation DAO balance should be zero
+    expect(await brn.balanceOf(dao.address)).to.equal(0);
+
+    // bot processes escalation which exceeds threshold (10)
+    await escalator.connect(bot).processEscalation(postHash);
+
+    // BRN transferred to DAO
+    expect(await brn.balanceOf(dao.address)).to.equal(15);
+
+    // stake should be cleared
+    expect(await escalator.brnStaked(postHash)).to.equal(0);
+    expect(await registry.brnStaked(postHash)).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add BRN slashing logic in `FlagEscalator`
- track per-post BRN stakes in `BurnRegistry`
- create `MockBRN` token for tests
- cover slashing behaviour in new Hardhat tests

## Testing
- `npm install` in `ado-core`
- `npx hardhat test test/FlagEscalator.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6859dc3a55a483338f99fc252c6cce28