### PR TITLE
Add slash history route and component

### DIFF
--- a/pages/api/post/[hash]/slash-history.ts
+++ b/pages/api/post/[hash]/slash-history.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getLogs } from "@/utils/getLogs";
+import FlagEscalatorABI from "@/abi/FlagEscalator.json";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { hash } = req.query;
+  if (!hash || typeof hash !== "string") return res.status(400).json({ error: "Invalid hash" });
+
+  try {
+    const logs = await getLogs("FlagEscalator", FlagEscalatorABI, "PostSlashed", {
+      postHash: hash,
+    });
+
+    res.status(200).json({ slashes: logs });
+  } catch (e) {
+    res.status(500).json({ error: "Failed to fetch slash history" });
+  }
+}

--- a/thisrightnow/src/abi/FlagEscalator.json
+++ b/thisrightnow/src/abi/FlagEscalator.json
@@ -1,0 +1,27 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "brnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "treasury",
+        "type": "address"
+      }
+    ],
+    "name": "PostSlashed",
+    "type": "event"
+  }
+]

--- a/thisrightnow/src/components/SlashHistory.tsx
+++ b/thisrightnow/src/components/SlashHistory.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export default function SlashHistory({ hash }: { hash: string }) {
+  const [slashes, setSlashes] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/post/${hash}/slash-history`)
+      .then((res) => res.json())
+      .then((data) => setSlashes(data.slashes || []));
+  }, [hash]);
+
+  if (slashes.length === 0) return null;
+
+  return (
+    <div className="mt-4 text-sm text-red-600">
+      <h4 className="font-bold">🔥 This post was slashed</h4>
+      <ul>
+        {slashes.map((s, i) => (
+          <li key={i}>
+            <div>Amount: {s.args?.brn} BRN</div>
+            <div>Sent to DAO at: {s.args?.daoTreasury}</div>
+            <div>Block: {s.blockNumber}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/thisrightnow/src/pages/post/[hash].tsx
+++ b/thisrightnow/src/pages/post/[hash].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import PostEarnings from "@/components/PostEarnings";
+import SlashHistory from "@/components/SlashHistory";
 
 export default function PostPage() {
   const router = useRouter();
@@ -12,6 +13,7 @@ export default function PostPage() {
       <h1 className="text-2xl font-bold mb-4">Post {hash}</h1>
       {/* Post content would go here */}
       <PostEarnings postHash={hash as string} />
+      <SlashHistory hash={hash as string} />
       <div className="mt-4">
         <h2 className="font-semibold">🔁 Retrns</h2>
         {/* retrns list placeholder */}

--- a/utils/getLogs.ts
+++ b/utils/getLogs.ts
@@ -1,0 +1,13 @@
+import { loadContract } from "./contract";
+
+export async function getLogs(
+  contractName: string,
+  abi: any,
+  eventName: string,
+  args: Record<string, any> = {}
+) {
+  const contract = await loadContract(contractName, abi);
+  const filterFn = (contract as any).filters?.[eventName];
+  const filter = filterFn ? filterFn(...Object.values(args)) : [];
+  return await contract.queryFilter(filter);
+}


### PR DESCRIPTION
## Summary
- add API route to fetch post slash logs
- show slash history in the post page
- expose getLogs utility
- add FlagEscalator ABI for event decoding

## Testing
- `npm test` *(fails: needs hardhat package)*

------
https://chatgpt.com/codex/tasks/task_e_6859de7786c88333bca9a6bee8220fad