### PR TITLE
Add DAO slashing inflow metric

### DIFF
--- a/indexer/abis/FlagEscalator.json
+++ b/indexer/abis/FlagEscalator.json
@@ -1,0 +1,27 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "postHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "brnAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "treasury",
+        "type": "address"
+      }
+    ],
+    "name": "PostSlashed",
+    "type": "event"
+  }
+]

--- a/indexer/aggregateEarnings.ts
+++ b/indexer/aggregateEarnings.ts
@@ -1,1 +1,33 @@
 export { aggregateEarnings } from './aggregator';
+
+import { getViewEarnings } from './sources/views';
+import { getRetrnEarnings } from './sources/retrns';
+import { getBoostEarnings } from './sources/boost';
+import { getVaultEarnings } from './sources/vaults';
+import { getLottoEarnings } from './sources/lotto';
+import { getSlashingInflow } from './sources/slashing';
+
+function sum(obj: Record<string, number>): number {
+  return Object.values(obj).reduce((a, b) => a + b, 0);
+}
+
+export async function aggregateInflow() {
+  const [views, retrns, boosts, vaults, lotto] = await Promise.all([
+    getViewEarnings(),
+    getRetrnEarnings(),
+    getBoostEarnings(),
+    getVaultEarnings(),
+    getLottoEarnings(),
+  ]);
+
+  const slashing = await getSlashingInflow();
+
+  return {
+    view: sum(views),
+    retrn: sum(retrns),
+    boost: sum(boosts),
+    vaults: sum(vaults),
+    lotto: sum(lotto),
+    slashing,
+  };
+}

--- a/indexer/sources/slashing.ts
+++ b/indexer/sources/slashing.ts
@@ -1,0 +1,13 @@
+import { getLogs } from "../utils/getLogs";
+import FlagEscalatorABI from "../abis/FlagEscalator.json";
+
+export async function getSlashingInflow(): Promise<number> {
+  const logs = await getLogs("FlagEscalator", FlagEscalatorABI, "PostSlashed");
+
+  const total = logs.reduce((acc: number, log: any) => {
+    const amount = Number(log.args?.brnAmount || 0);
+    return acc + amount;
+  }, 0);
+
+  return total;
+}

--- a/pages/api/dao/inflow.ts
+++ b/pages/api/dao/inflow.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { aggregateInflow } from "@/indexer/aggregateEarnings";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const data = await aggregateInflow();
+    res.status(200).json(data);
+  } catch (e) {
+    res.status(500).json({ error: "Failed to fetch inflow" });
+  }
+}

--- a/thisrightnow/src/pages/payouts.tsx
+++ b/thisrightnow/src/pages/payouts.tsx
@@ -2,11 +2,18 @@ import { useEffect, useState } from "react";
 
 export default function PayoutsDashboard() {
   const [data, setData] = useState<any>(null);
+  const [inflow, setInflow] = useState<any>(null);
 
   useEffect(() => {
     fetch("http://localhost:4000/api/payouts")
       .then((res) => res.json())
       .then(setData);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/dao/inflow")
+      .then((res) => res.json())
+      .then(setInflow);
   }, []);
 
   if (!data) return <p className="p-4">Loading DAO payout summary...</p>;
@@ -22,6 +29,13 @@ export default function PayoutsDashboard() {
         <p className="text-2xl">{totalRevenue.toFixed(2)} TRN</p>
         <p className="text-xs text-gray-600">Last split: {lastSplitDate}</p>
       </div>
+
+      {inflow && (
+        <div className="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
+          <h3 className="text-red-800 font-bold">🔥 Slashing Inflow</h3>
+          <p>{Number(inflow.slashing || 0).toFixed(2)} BRN redirected to DAO</p>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-4">
         {Object.entries(breakdown).map(([label, value]) => (


### PR DESCRIPTION
## Summary
- indexer: track slashing inflow from `FlagEscalator.PostSlashed`
- expose new `aggregateInflow` helper
- API route to serve DAO inflow data
- display slashing inflow on payouts dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `ado-core` *(fails: requires hardhat installation)*

------
https://chatgpt.com/codex/tasks/task_e_6859e0acef608333bf2056b0c094fcbe