### PR TITLE
Add slashing heatmap

### DIFF
--- a/components/WorldHeatmap.tsx
+++ b/components/WorldHeatmap.tsx
@@ -1,0 +1,26 @@
+import { ComposableMap, Geographies, Geography } from "react-simple-maps";
+import { scaleLinear } from "d3-scale";
+
+const geoUrl = "https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json";
+
+export default function WorldHeatmap({ data }: { data: Record<string, number> }) {
+  const values = Object.values(data);
+  const max = values.length ? Math.max(...values) : 0;
+  const color = scaleLinear<string>().domain([0, max || 1]).range(["#ffedea", "#ff5233"]);
+
+  return (
+    <ComposableMap projectionConfig={{ scale: 150 }}>
+      <Geographies geography={geoUrl}>
+        {({ geographies }) =>
+          geographies.map((geo) => {
+            const code = (geo.properties as any).ISO_A2 as string;
+            const val = data[code] || 0;
+            return (
+              <Geography key={geo.rsmKey} geography={geo} fill={val ? color(val) : "#EEE"} />
+            );
+          })
+        }
+      </Geographies>
+    </ComposableMap>
+  );
+}

--- a/indexer/aggregateEarnings.ts
+++ b/indexer/aggregateEarnings.ts
@@ -6,6 +6,7 @@ import { getBoostEarnings } from './sources/boost';
 import { getVaultEarnings } from './sources/vaults';
 import { getLottoEarnings } from './sources/lotto';
 import { getSlashingInflow } from './sources/slashing';
+import { getSlashingByCountry } from './sources/slashingByCountry';
 
 function sum(obj: Record<string, number>): number {
   return Object.values(obj).reduce((a, b) => a + b, 0);
@@ -21,6 +22,7 @@ export async function aggregateInflow() {
   ]);
 
   const slashing = await getSlashingInflow();
+  const slashingByRegion = await getSlashingByCountry();
 
   return {
     view: sum(views),
@@ -29,5 +31,6 @@ export async function aggregateInflow() {
     vaults: sum(vaults),
     lotto: sum(lotto),
     slashing,
+    slashingByRegion,
   };
 }

--- a/indexer/sources/slashingByCountry.ts
+++ b/indexer/sources/slashingByCountry.ts
@@ -1,0 +1,20 @@
+import { getLogs } from "../utils/getLogs";
+import FlagEscalatorABI from "../../abi/FlagEscalator.json";
+import { getGeoDataForPost } from "../utils/postGeoLookup";
+
+export async function getSlashingByCountry(): Promise<Record<string, number>> {
+  const logs = await getLogs("FlagEscalator", FlagEscalatorABI, "PostSlashed");
+  const countryMap: Record<string, number> = {};
+
+  for (const log of logs) {
+    const postHash = log.args?.postHash;
+    const brn = Number(log.args?.brn || 0);
+    const geo = await getGeoDataForPost(postHash); // ISO-3166 alpha-2 code
+
+    if (!geo) continue;
+
+    countryMap[geo] = (countryMap[geo] || 0) + brn;
+  }
+
+  return countryMap;
+}

--- a/indexer/utils/postGeoLookup.ts
+++ b/indexer/utils/postGeoLookup.ts
@@ -1,0 +1,5 @@
+import geoMap from "../../src/data/post-geo.json";
+
+export async function getGeoDataForPost(hash: string): Promise<string | null> {
+  return (geoMap as Record<string, string>)[hash] || null;
+}

--- a/pages/analytics/slashing-map.tsx
+++ b/pages/analytics/slashing-map.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+// Load map client-side
+const MapChart = dynamic(() => import("@/components/WorldHeatmap"), { ssr: false });
+
+export default function SlashingMapPage() {
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    fetch("/api/dao/slashing-map")
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">🌍 Regional Slashing Heatmap</h1>
+      <MapChart data={data} />
+    </div>
+  );
+}

--- a/pages/api/dao/slashing-map.ts
+++ b/pages/api/dao/slashing-map.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSlashingByCountry } from "@/indexer/sources/slashingByCountry";
+
+export default async function handler(_: NextApiRequest, res: NextApiResponse) {
+  const data = await getSlashingByCountry();
+  res.status(200).json(data);
+}

--- a/src/data/post-geo.json
+++ b/src/data/post-geo.json
@@ -1,0 +1,5 @@
+{
+  "0xhash1": "US",
+  "0xhash2": "GB",
+  "0xhash3": "FR"
+}


### PR DESCRIPTION
## Summary
- track slashing volume by country using post geo lookup
- expose new slashing-map API
- display heatmap on analytics page
- include example post geo data
- provide WorldHeatmap component

## Testing
- `npm ci` in `ado-core`
- `npx hardhat test`
- `npx --yes ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm ci` in `thisrightnow`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6859e73c9c848333bdfc7470969e28c7