### PR TITLE
Add slashing by category analytics

### DIFF
--- a/indexer/aggregateEarnings.ts
+++ b/indexer/aggregateEarnings.ts
@@ -7,6 +7,7 @@ import { getVaultEarnings } from './sources/vaults';
 import { getLottoEarnings } from './sources/lotto';
 import { getSlashingInflow } from './sources/slashing';
 import { getSlashingByCountry } from './sources/slashingByCountry';
+import { getSlashingByCountryAndCategory } from './sources/slashingByCountryAndCategory';
 
 function sum(obj: Record<string, number>): number {
   return Object.values(obj).reduce((a, b) => a + b, 0);
@@ -23,6 +24,7 @@ export async function aggregateInflow() {
 
   const slashing = await getSlashingInflow();
   const slashingByRegion = await getSlashingByCountry();
+  const slashingByCategoryAndRegion = await getSlashingByCountryAndCategory();
 
   return {
     view: sum(views),
@@ -32,5 +34,6 @@ export async function aggregateInflow() {
     lotto: sum(lotto),
     slashing,
     slashingByRegion,
+    slashingByCategoryAndRegion,
   };
 }

--- a/indexer/sources/slashingByCountryAndCategory.ts
+++ b/indexer/sources/slashingByCountryAndCategory.ts
@@ -1,0 +1,23 @@
+import { getLogs } from "../utils/getLogs";
+import FlagEscalatorABI from "../../abi/FlagEscalator.json";
+import { getGeoDataForPost, getCategoryForPost } from "../utils/postGeoLookup";
+
+export async function getSlashingByCountryAndCategory(): Promise<Record<string, Record<string, number>>> {
+  const logs = await getLogs("FlagEscalator", FlagEscalatorABI, "PostSlashed");
+  const map: Record<string, Record<string, number>> = {};
+
+  for (const log of logs) {
+    const postHash = log.args?.postHash;
+    const brn = Number(log.args?.brn || 0);
+
+    const geo = await getGeoDataForPost(postHash); // e.g. "US"
+    const category = await getCategoryForPost(postHash); // e.g. "satire"
+
+    if (!geo || !category) continue;
+
+    if (!map[geo]) map[geo] = {};
+    map[geo][category] = (map[geo][category] || 0) + brn;
+  }
+
+  return map;
+}

--- a/indexer/utils/postGeoLookup.ts
+++ b/indexer/utils/postGeoLookup.ts
@@ -1,5 +1,10 @@
 import geoMap from "../../src/data/post-geo.json";
+import categoryMap from "../../src/data/post-category.json";
 
 export async function getGeoDataForPost(hash: string): Promise<string | null> {
   return (geoMap as Record<string, string>)[hash] || null;
+}
+
+export async function getCategoryForPost(hash: string): Promise<string | null> {
+  return (categoryMap as Record<string, string>)[hash] || null;
 }

--- a/pages/analytics/slashing-category-map.tsx
+++ b/pages/analytics/slashing-category-map.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
+
+const MapChart = dynamic(() => import("@/components/WorldHeatmap"), { ssr: false });
+
+export default function SlashingCategoryMapPage() {
+  const [data, setData] = useState<Record<string, Record<string, number>>>({});
+  const [category, setCategory] = useState("");
+
+  useEffect(() => {
+    fetch("/api/dao/slashing-category-map")
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  const categories = Array.from(
+    new Set(
+      Object.values(data).flatMap((m) => Object.keys(m))
+    )
+  );
+
+  const mapData = Object.fromEntries(
+    Object.entries(data).map(([country, cats]) => [country, cats[category] || 0])
+  );
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">🔥 Slashing by Category &amp; Region</h1>
+      <select
+        className="border p-2 mb-4"
+        value={category}
+        onChange={(e) => setCategory(e.target.value)}
+      >
+        <option value="">Select category</option>
+        {categories.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      {category && <MapChart data={mapData} />}
+    </div>
+  );
+}

--- a/pages/api/dao/slashing-category-map.ts
+++ b/pages/api/dao/slashing-category-map.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSlashingByCountryAndCategory } from "@/indexer/sources/slashingByCountryAndCategory";
+
+export default async function handler(_: NextApiRequest, res: NextApiResponse) {
+  const data = await getSlashingByCountryAndCategory();
+  res.status(200).json(data);
+}

--- a/src/data/post-category.json
+++ b/src/data/post-category.json
@@ -1,0 +1,5 @@
+{
+  "0xhash1": "satire",
+  "0xhash2": "politics",
+  "0xhash3": "health"
+}


### PR DESCRIPTION
## Summary
- expose per-category slashing data via a new source, API route and page
- track post categories in `post-category.json`
- aggregate slashing by region + category

## Testing
- `npx hardhat test` *(fails: Cannot find module 'ethers')*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails to compile TypeScript)*
- `npm run lint` in `thisrightnow` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6859e94aa81c8333b3003287b8a96955