### PR TITLE
Add slashing summary with CSV report

### DIFF
--- a/pages/analytics/dao.tsx
+++ b/pages/analytics/dao.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+export default function DAOAnalytics() {
+  const [data, setData] = useState<any>(null);
+
+  useEffect(() => {
+    fetch("/api/dao/inflow")
+      .then((res) => res.json())
+      .then(setData);
+  }, []);
+
+  if (!data) return <p className="p-4">Loading analytics...</p>;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">🏛️ DAO Inflow Analytics</h1>
+      <h2 className="text-xl font-bold mt-8">🔥 Slashing Summary</h2>
+      <ul>
+        {Object.entries(data.slashingByCategoryAndRegion).map(
+          ([country, catMap]) => (
+            <li key={country}>
+              <strong>{country}:</strong>{" "}
+              {Object.entries(catMap)
+                .map(([cat, brn]) => `${cat}: ${brn} BRN`)
+                .join(", ")}
+            </li>
+          )
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/pages/api/admin/reports/slashing.csv.ts
+++ b/pages/api/admin/reports/slashing.csv.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getSlashingByCountryAndCategory } from "@/indexer/sources/slashingByCountryAndCategory";
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const data = await getSlashingByCountryAndCategory();
+  const rows: string[] = ["country,category,brn"];
+
+  for (const [country, cats] of Object.entries(data)) {
+    for (const [cat, brn] of Object.entries(cats)) {
+      rows.push(`${country},${cat},${brn}`);
+    }
+  }
+
+  const csv = rows.join("\n");
+  res.setHeader("Content-Type", "text/csv");
+  res.setHeader("Content-Disposition", "attachment; filename=slashing.csv");
+  res.status(200).send(csv);
+}

--- a/thisrightnow/src/pages/payouts.tsx
+++ b/thisrightnow/src/pages/payouts.tsx
@@ -34,6 +34,24 @@ export default function PayoutsDashboard() {
         <div className="bg-red-50 border-l-4 border-red-500 p-4 mb-6">
           <h3 className="text-red-800 font-bold">🔥 Slashing Inflow</h3>
           <p>{Number(inflow.slashing || 0).toFixed(2)} BRN redirected to DAO</p>
+
+          {inflow.slashingByCategoryAndRegion && (
+            <>
+              <h2 className="text-xl font-bold mt-8">🔥 Slashing Summary</h2>
+              <ul>
+                {Object.entries(inflow.slashingByCategoryAndRegion).map(
+                  ([country, catMap]) => (
+                    <li key={country}>
+                      <strong>{country}:</strong>{" "}
+                      {Object.entries(catMap)
+                        .map(([cat, brn]) => `${cat}: ${brn} BRN`)
+                        .join(", ")}
+                    </li>
+                  )
+                )}
+              </ul>
+            </>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- enhance DAO payout dashboard with breakdown by region & category
- add DAO analytics page for viewing slashing summary
- expose `/api/admin/reports/slashing.csv` for CSV export

## Testing
- `npx hardhat test`
- `npm run lint` in `thisrightnow`

------
https://chatgpt.com/codex/tasks/task_e_6859eb51d57083339f24c656f4fbd8df