### PR TITLE
Add real-time moderation alert panel

### DIFF
--- a/pages/admin/mod-alerts.tsx
+++ b/pages/admin/mod-alerts.tsx
@@ -1,30 +1,45 @@
 import { useEffect, useState } from "react";
 
 export default function ModAlertsPage() {
-  const [alerts, setAlerts] = useState([] as Array<any>);
+  const [alerts, setAlerts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/alerts/slashing")
-      .then((res) => res.json())
-      .then(setAlerts);
+    const fetchAlerts = async () => {
+      const res = await fetch("/api/slashing/alerts");
+      const data = await res.json();
+      setAlerts(data.alerts || []);
+      setLoading(false);
+    };
+
+    fetchAlerts();
+    const interval = setInterval(fetchAlerts, 30_000); // Refresh every 30s
+    return () => clearInterval(interval);
   }, []);
 
   return (
-    <div className="max-w-3xl mx-auto p-6">
-      <h1 className="text-2xl font-bold mb-4">🔥 BRN Slashing Alerts</h1>
-      {alerts.length === 0 ? (
-        <p>No burn thresholds exceeded.</p>
-      ) : (
-        <ul className="space-y-4">
-          {alerts.map((a, i) => (
-            <li key={i} className="p-4 bg-red-100 border-l-4 border-red-500">
-              <strong>{a.country}</strong> exceeded the <strong>{a.category}</strong> threshold.
-              <br />
-              <span>{a.brn} BRN burned vs threshold of {a.threshold}</span>
-            </li>
-          ))}
-        </ul>
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-6">🛡️ Moderation Alert Panel</h1>
+
+      {loading && <p>Loading alerts...</p>}
+
+      {!loading && alerts.length === 0 && (
+        <p className="text-green-600">✅ No thresholds exceeded at this time.</p>
       )}
+
+      <ul className="space-y-4">
+        {alerts.map((a, i) => (
+          <li key={i} className="border p-4 rounded bg-white shadow">
+            <p className="font-semibold">
+              🚨 {a.category} posts in <strong>{a.country}</strong> triggered an alert!
+            </p>
+            <p className="text-sm mt-1 text-gray-600">
+              Burned: <strong>{a.amount} BRN</strong> — Threshold: {a.threshold} BRN
+            </p>
+            <p className="text-xs text-gray-500 mt-2">Real-time auto-feed from on-chain data.</p>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement real-time mod alerts page using `/api/slashing/alerts`

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a0936334883339200345d6abcc561