### PR TITLE
Add moderation proposal actions

### DIFF
--- a/pages/admin/mod-alerts.tsx
+++ b/pages/admin/mod-alerts.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
+import { createProposal } from "@/utils/proposals";
 
 export default function ModAlertsPage() {
   const [alerts, setAlerts] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [proposing, setProposing] = useState(false);
+  const [proposalStatus, setProposalStatus] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchAlerts = async () => {
@@ -16,6 +19,30 @@ export default function ModAlertsPage() {
     const interval = setInterval(fetchAlerts, 30_000); // Refresh every 30s
     return () => clearInterval(interval);
   }, []);
+
+  const handlePropose = async (
+    alert: any,
+    type: "mute" | "geo" | "dao",
+  ) => {
+    setProposing(true);
+    setProposalStatus(null);
+
+    try {
+      const payload = {
+        country: alert.country,
+        category: alert.category,
+        actionType: type,
+      };
+
+      await createProposal(payload);
+      setProposalStatus("✅ Proposal submitted!");
+    } catch (err) {
+      console.error(err);
+      setProposalStatus("❌ Failed to submit proposal.");
+    }
+
+    setProposing(false);
+  };
 
   return (
     <div className="max-w-5xl mx-auto p-6">
@@ -37,6 +64,34 @@ export default function ModAlertsPage() {
               Burned: <strong>{a.amount} BRN</strong> — Threshold: {a.threshold} BRN
             </p>
             <p className="text-xs text-gray-500 mt-2">Real-time auto-feed from on-chain data.</p>
+
+            <div className="mt-4 flex gap-2">
+              <button
+                onClick={() => handlePropose(a, "mute")}
+                className="bg-yellow-500 text-white px-3 py-1 rounded text-sm"
+                disabled={proposing}
+              >
+                Mute Category
+              </button>
+
+              <button
+                onClick={() => handlePropose(a, "geo")}
+                className="bg-red-600 text-white px-3 py-1 rounded text-sm"
+                disabled={proposing}
+              >
+                Geo Ban
+              </button>
+
+              <button
+                onClick={() => handlePropose(a, "dao")}
+                className="bg-blue-600 text-white px-3 py-1 rounded text-sm"
+                disabled={proposing}
+              >
+                Propose DAO Vote
+              </button>
+            </div>
+
+            {proposalStatus && <p className="text-xs mt-2">{proposalStatus}</p>}
           </li>
         ))}
       </ul>

--- a/utils/proposals.ts
+++ b/utils/proposals.ts
@@ -1,0 +1,21 @@
+import { loadContract } from "./contract";
+import { ethers } from "ethers";
+
+const abi = [
+  "function createProposal(bytes actionData) external returns (uint256)"
+];
+
+export async function createProposal(data: {
+  country: string;
+  category: string;
+  actionType: string;
+}) {
+  const contract = await loadContract("ProposalFactory", abi);
+  const encoded = ethers.AbiCoder.defaultAbiCoder().encode(
+    ["string", "string", "string"],
+    [data.country, data.category, data.actionType]
+  );
+  const tx = await contract.createProposal(encoded);
+  await tx.wait();
+  return tx.hash;
+}


### PR DESCRIPTION
## Summary
- empower moderators to propose actions in `/admin/mod-alerts`
- create helper to call `ProposalFactory.createProposal`

## Testing
- `npx hardhat test` *(from `ado-core`)*
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: Cannot find module 'ethers')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685a0b2efa3c8333bd7acab50c37759a