### PR TITLE
Add DAO governance contracts and tests

### DIFF
--- a/ado-core/contracts/CouncilNFT.sol
+++ b/ado-core/contracts/CouncilNFT.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @title CouncilNFT
+/// @notice Simple NFT representing DAO council membership.
+contract CouncilNFT is ERC721 {
+    uint256 public nextId = 1;
+
+    constructor() ERC721("CouncilNFT", "COUNCIL") {}
+
+    /// @notice Mint a new council token to `to`.
+    function mint(address to) external {
+        _mint(to, nextId++);
+    }
+}

--- a/ado-core/contracts/MasterNFT.sol
+++ b/ado-core/contracts/MasterNFT.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+/// @title MasterNFT
+/// @notice NFT that grants veto/approval power in the DAO.
+contract MasterNFT is ERC721 {
+    uint256 public nextId = 1;
+
+    constructor() ERC721("MasterNFT", "MASTER") {}
+
+    /// @notice Mint a new master token to `to`.
+    function mint(address to) external {
+        _mint(to, nextId++);
+    }
+}

--- a/ado-core/contracts/ProposalFactory.sol
+++ b/ado-core/contracts/ProposalFactory.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title ProposalFactory
+/// @notice Simplified governance proposal manager for testing.
+contract ProposalFactory {
+    enum Status { Created, Passed, Approved, Vetoed }
+
+    struct Proposal {
+        string description;
+        Status status;
+    }
+
+    IERC721 public councilNFT;
+    IERC721 public masterNFT;
+
+    uint256 public proposalCount;
+    mapping(uint256 => Proposal) public proposals;
+
+    event ProposalCreated(uint256 indexed proposalId, string description);
+    event ProposalPassed(uint256 indexed proposalId);
+    event ProposalApproved(uint256 indexed proposalId);
+    event ProposalVetoed(uint256 indexed proposalId);
+
+    constructor(address _councilNFT, address _masterNFT) {
+        councilNFT = IERC721(_councilNFT);
+        masterNFT = IERC721(_masterNFT);
+    }
+
+    modifier onlyCouncil() {
+        require(councilNFT.balanceOf(msg.sender) > 0, "Not council");
+        _;
+    }
+
+    modifier onlyMaster() {
+        require(masterNFT.balanceOf(msg.sender) > 0, "Not master");
+        _;
+    }
+
+    function createProposal(string calldata description, uint8 /*category*/) external onlyCouncil returns (uint256) {
+        proposalCount++;
+        proposals[proposalCount] = Proposal(description, Status.Created);
+        emit ProposalCreated(proposalCount, description);
+        return proposalCount;
+    }
+
+    function passProposal(uint256 id) external onlyCouncil {
+        Proposal storage p = proposals[id];
+        require(p.status == Status.Created, "Already passed");
+        p.status = Status.Passed;
+        emit ProposalPassed(id);
+    }
+
+    function approveProposal(uint256 id) external onlyMaster {
+        Proposal storage p = proposals[id];
+        require(p.status == Status.Passed, "Not passed");
+        p.status = Status.Approved;
+        emit ProposalApproved(id);
+    }
+
+    function vetoProposal(uint256 id) external onlyMaster {
+        Proposal storage p = proposals[id];
+        require(p.status == Status.Passed, "Not passed");
+        p.status = Status.Vetoed;
+        emit ProposalVetoed(id);
+    }
+
+    function getProposalStatus(uint256 id) external view returns (uint8) {
+        return uint8(proposals[id].status);
+    }
+}

--- a/ado-core/test/ProposalFlow.test.ts
+++ b/ado-core/test/ProposalFlow.test.ts
@@ -1,0 +1,73 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("DAO Proposal Lifecycle", () => {
+  let master: any, council: any, user1: any, user2: any;
+  let ProposalFactory: any, proposalFactory: any;
+
+  beforeEach(async () => {
+    [master, council, user1, user2] = await ethers.getSigners();
+
+    const CouncilNFT = await ethers.getContractFactory("CouncilNFT");
+    const MasterNFT = await ethers.getContractFactory("MasterNFT");
+    const ProposalFactoryContract = await ethers.getContractFactory("ProposalFactory");
+
+    const councilNFT = await CouncilNFT.deploy();
+    const masterNFT = await MasterNFT.deploy();
+
+    await councilNFT.mint(council.address);
+    await masterNFT.mint(master.address);
+
+    ProposalFactory = await ProposalFactoryContract.deploy(councilNFT.target, masterNFT.target);
+    proposalFactory = ProposalFactory.connect(council);
+  });
+
+  it("should create a proposal", async () => {
+    const tx = await proposalFactory.createProposal("Mute category X", 1);
+    const receipt = await tx.wait();
+    const event = receipt!.logs.find((e: any) => e.fragment?.name === "ProposalCreated");
+    expect(event?.args?.description).to.equal("Mute category X");
+  });
+
+  it("should allow Council to pass a proposal", async () => {
+    const idTx = await proposalFactory.createProposal("Ban content", 2);
+    const receipt = await idTx.wait();
+    const id = receipt!.logs[0]!.args!.proposalId;
+
+    await proposalFactory.passProposal(id);
+    const status = await proposalFactory.getProposalStatus(id);
+    expect(status).to.equal(1);
+  });
+
+  it("should allow Master to veto", async () => {
+    const idTx = await proposalFactory.createProposal("Allow spam", 3);
+    const id = (await idTx.wait()).logs[0].args.proposalId;
+
+    await proposalFactory.passProposal(id);
+    const masterConnected = ProposalFactory.connect(master);
+    await masterConnected.vetoProposal(id);
+
+    const status = await ProposalFactory.getProposalStatus(id);
+    expect(status).to.equal(3);
+  });
+
+  it("should allow full passage to user vote", async () => {
+    const idTx = await proposalFactory.createProposal("Mute Y", 5);
+    const id = (await idTx.wait()).logs[0].args.proposalId;
+
+    await proposalFactory.passProposal(id);
+    const masterConnected = ProposalFactory.connect(master);
+    await masterConnected.approveProposal(id);
+
+    const status = await ProposalFactory.getProposalStatus(id);
+    expect(status).to.equal(2);
+  });
+
+  it("should not allow duplicate execution or invalid state transitions", async () => {
+    const idTx = await proposalFactory.createProposal("Test", 5);
+    const id = (await idTx.wait()).logs[0].args.proposalId;
+
+    await proposalFactory.passProposal(id);
+    await expect(proposalFactory.passProposal(id)).to.be.revertedWith("Already passed");
+  });
+});


### PR DESCRIPTION
## Summary
- implement `CouncilNFT`, `MasterNFT`, and `ProposalFactory` contracts
- add `ProposalFlow.test.ts` covering the DAO proposal lifecycle

## Testing
- `npm install` within `ado-core`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_685a11df0fc88333927173b1393034e9