### PR TITLE
Implement TRN based proposal voting

### DIFF
--- a/ado-core/contracts/MockCountryRulesetManager.sol
+++ b/ado-core/contracts/MockCountryRulesetManager.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract MockCountryRulesetManager {
+    event CategoryMuted(string country, string category, bool muted);
+
+    function setCategoryMuted(
+        string calldata country,
+        string calldata category,
+        bool muted
+    ) external {
+        emit CategoryMuted(country, category, muted);
+    }
+}

--- a/ado-core/contracts/MockVoterNFT.sol
+++ b/ado-core/contracts/MockVoterNFT.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MockVoterNFT is ERC721 {
+    uint256 public nextId = 1;
+
+    constructor() ERC721("VoterNFT", "VOTE") {}
+
+    function mint(address to) external {
+        _mint(to, nextId++);
+    }
+}

--- a/ado-core/contracts/ProposalFactory.sol
+++ b/ado-core/contracts/ProposalFactory.sol
@@ -2,6 +2,19 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "./TRNUsageOracle.sol";
+
+interface IVoterNFT {
+    function balanceOf(address owner) external view returns (uint256);
+}
+
+interface ICountryRulesetManager {
+    function setCategoryMuted(
+        string calldata country,
+        string calldata category,
+        bool muted
+    ) external;
+}
 
 /// @title ProposalFactory
 /// @notice Simplified governance proposal manager for testing.
@@ -9,24 +22,44 @@ contract ProposalFactory {
     enum Status { Created, Passed, Approved, Vetoed }
 
     struct Proposal {
+        string title;
         string description;
+        bytes payload;
         Status status;
+        uint256 yesVotes;
+        uint256 noVotes;
+        bool executed;
+        mapping(address => bool) voted;
     }
 
     IERC721 public councilNFT;
     IERC721 public masterNFT;
+    TRNUsageOracle public oracle;
+    IVoterNFT public voterNFT;
+    ICountryRulesetManager public rulesetManager;
 
     uint256 public proposalCount;
     mapping(uint256 => Proposal) public proposals;
 
-    event ProposalCreated(uint256 indexed proposalId, string description);
+    event ProposalCreated(uint256 indexed proposalId, string title);
     event ProposalPassed(uint256 indexed proposalId);
     event ProposalApproved(uint256 indexed proposalId);
     event ProposalVetoed(uint256 indexed proposalId);
+    event Voted(uint256 indexed proposalId, address indexed voter, bool support);
+    event Executed(uint256 indexed proposalId);
 
-    constructor(address _councilNFT, address _masterNFT) {
+    constructor(
+        address _councilNFT,
+        address _masterNFT,
+        address _oracle,
+        address _voterNFT,
+        address _rulesetManager
+    ) {
         councilNFT = IERC721(_councilNFT);
         masterNFT = IERC721(_masterNFT);
+        oracle = TRNUsageOracle(_oracle);
+        voterNFT = IVoterNFT(_voterNFT);
+        rulesetManager = ICountryRulesetManager(_rulesetManager);
     }
 
     modifier onlyCouncil() {
@@ -39,10 +72,18 @@ contract ProposalFactory {
         _;
     }
 
-    function createProposal(string calldata description, uint8 /*category*/) external onlyCouncil returns (uint256) {
+    function createProposal(
+        string calldata title,
+        string calldata description,
+        bytes calldata payload
+    ) external onlyCouncil returns (uint256) {
         proposalCount++;
-        proposals[proposalCount] = Proposal(description, Status.Created);
-        emit ProposalCreated(proposalCount, description);
+        Proposal storage p = proposals[proposalCount];
+        p.title = title;
+        p.description = description;
+        p.payload = payload;
+        p.status = Status.Created;
+        emit ProposalCreated(proposalCount, title);
         return proposalCount;
     }
 
@@ -65,6 +106,40 @@ contract ProposalFactory {
         require(p.status == Status.Passed, "Not passed");
         p.status = Status.Vetoed;
         emit ProposalVetoed(id);
+    }
+
+    function vote(uint256 proposalId, bool support) external {
+        require(voterNFT.balanceOf(msg.sender) > 0, "Not a voter");
+        Proposal storage p = proposals[proposalId];
+        require(!p.voted[msg.sender], "Already voted");
+
+        oracle.reportSpend(msg.sender, 1e18, "vote");
+
+        if (support) {
+            p.yesVotes += 1;
+        } else {
+            p.noVotes += 1;
+        }
+
+        p.voted[msg.sender] = true;
+
+        emit Voted(proposalId, msg.sender, support);
+    }
+
+    function executeProposal(uint256 proposalId) external {
+        Proposal storage p = proposals[proposalId];
+        require(!p.executed, "Already executed");
+        require(p.yesVotes > p.noVotes, "Proposal did not pass");
+
+        (string memory action, string memory category, string memory country) =
+            abi.decode(p.payload, (string, string, string));
+
+        if (keccak256(bytes(action)) == keccak256("muteCategory")) {
+            rulesetManager.setCategoryMuted(country, category, true);
+        }
+
+        p.executed = true;
+        emit Executed(proposalId);
     }
 
     function getProposalStatus(uint256 id) external view returns (uint8) {

--- a/thisrightnow/src/pages/api/slashing/alerts.ts
+++ b/thisrightnow/src/pages/api/slashing/alerts.ts
@@ -2,7 +2,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { loadContract } from "@/utils/contract";
 import SlashingPolicyABI from "@/abi/SlashingPolicyManager.json";
 import { fetchRecentSlashingEvents } from "@/utils/fetchLogs";
-import countryCodes from "@/data/countryCodes.json";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {


### PR DESCRIPTION
## Summary
- extend ProposalFactory with TRN voting logic
- add mock contracts for VoterNFT and CountryRulesetManager
- update proposal flow tests for new constructor and createProposal
- fix unused import in alerts API

## Testing
- `npx hardhat test`
- `npm run lint` in `thisrightnow`

------
https://chatgpt.com/codex/tasks/task_e_685a143003488333a5d15ddd97255ea4