### PR TITLE
Add shard recovery approval UI

### DIFF
--- a/thisrightnow/src/components/ShardApprovalButton.tsx
+++ b/thisrightnow/src/components/ShardApprovalButton.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { approveRecovery } from "@/utils/recovery";
+
+export default function ShardApprovalButton({
+  contributor,
+  shardIndex,
+  onApproved,
+}: {
+  contributor: string;
+  shardIndex: number;
+  onApproved?: () => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [approved, setApproved] = useState(false);
+
+  const handleApprove = async () => {
+    try {
+      setLoading(true);
+      await approveRecovery(contributor, shardIndex);
+      setApproved(true);
+      onApproved?.();
+    } catch (err) {
+      console.error("Approval failed", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (approved) {
+    return (
+      <button disabled className="bg-green-600 text-white px-3 py-1 rounded">
+        ✅ Approved
+      </button>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleApprove}
+      className="bg-blue-600 text-white px-3 py-1 rounded"
+      disabled={loading}
+    >
+      {loading ? "Approving..." : "Approve Recovery"}
+    </button>
+  );
+}

--- a/thisrightnow/src/utils/recovery.ts
+++ b/thisrightnow/src/utils/recovery.ts
@@ -39,3 +39,12 @@ export async function submitApproval() {
   const contract = await loadContract(CONTRACT_NAME, RecoveryOracleABI, wallet);
   return await contract.write.approveRecovery();
 }
+
+export async function approveRecovery(
+  contributor: string,
+  shardIndex: number,
+) {
+  const wallet = await getWalletClient();
+  const contract = await loadContract(CONTRACT_NAME, RecoveryOracleABI, wallet);
+  return await contract.write.approveRecovery([contributor, BigInt(shardIndex)]);
+}


### PR DESCRIPTION
## Summary
- add `ShardApprovalButton` component for shard holders to approve recovery events
- expand recovery utils with `approveRecovery(contributor, shardIndex)`

## Testing
- `npm run lint`
- `npx hardhat test` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685b485a47188333a44acf4b197f2a1f