### PR TITLE
Implement manual RecoveryOracle vault restoration

### DIFF
--- a/ado-core/contracts/RecoveryOracle.sol
+++ b/ado-core/contracts/RecoveryOracle.sol
@@ -98,11 +98,16 @@ contract RecoveryOracle {
         approvals.push(msg.sender);
 
         emit ShardApproved(msg.sender);
+    }
 
-        if (approvals.length >= REQUIRED_APPROVALS) {
-            recovered = true;
-            emit RecoveryCompleted(initiator);
-        }
+    /// @notice Finalize the recovery once enough approvals have been collected
+    function maybeRestoreVault() external {
+        require(!recovered, "Vault already restored");
+        require(approvals.length >= REQUIRED_APPROVALS, "Not enough approvals");
+
+        recovered = true;
+
+        emit RecoveryCompleted(initiator);
     }
 
     /// ---------------------------------------------------------------------

--- a/ado-core/test/RecoveryOracle.test.ts
+++ b/ado-core/test/RecoveryOracle.test.ts
@@ -37,7 +37,19 @@ describe("RecoveryOracle", () => {
       await oracle.connect(await ethers.getSigner(shardHolders[i])).approveRecovery();
     }
 
+    await oracle.maybeRestoreVault();
+
     expect(await oracle.isRecovered()).to.be.true;
+  });
+
+  it("should fail to finalize recovery before enough approvals", async () => {
+    await oracle.connect(nonShard).initiateRecovery();
+
+    await oracle.connect(await ethers.getSigner(shardHolders[0])).approveRecovery();
+
+    await expect(oracle.maybeRestoreVault()).to.be.revertedWith("Not enough approvals");
+
+    expect(await oracle.isRecovered()).to.be.false;
   });
 
   it("should not allow duplicate approvals", async () => {


### PR DESCRIPTION
## Summary
- extend `RecoveryOracle` with `maybeRestoreVault` to trigger recovery once 4-of-7 shards approve
- test manual restoration logic in `RecoveryOracle.test.ts`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b59f4f25c8333a334f23464ccd8e3