### PR TITLE
Fix IPFS upload env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,18 @@ AlphaDataOmega is a decentralized social protocol and economic system built to r
    cd ../thisrightnow && npm install
    ```
 
-4. Run tests and lint checks:
+4. Create a `.env` file inside `thisrightnow/` and set your NFT.Storage key:
+
+   ```bash
+   echo "VITE_NFT_STORAGE_KEY=<your key>" > thisrightnow/.env
+   ```
+
+5. Run tests and lint checks:
    - From `ado-core/` run `npx hardhat test`
    - Use `npx ts-node test/RetrnScoreEngine.test.ts` (or the provided npm script) for the standalone engine test
    - From `thisrightnow/` run `npm run lint`
 
-5. Suggested first steps:
+6. Suggested first steps:
    - Review `contracts/ViewIndex.sol`
    - Build out basic post/feed UI in `frontend/`
    - Test Merkle drop logic from `indexer/` hooks

--- a/thisrightnow/src/utils/uploadToIPFS.ts
+++ b/thisrightnow/src/utils/uploadToIPFS.ts
@@ -1,6 +1,8 @@
 import { NFTStorage } from "nft.storage";
 
-const client = new NFTStorage({ token: process.env.NFT_STORAGE_KEY! });
+const client = new NFTStorage({
+  token: import.meta.env.VITE_NFT_STORAGE_KEY as string,
+});
 
 export async function uploadToIPFS(post: any): Promise<string> {
   const blob = new Blob([JSON.stringify(post)], { type: "application/json" });


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_NFT_STORAGE_KEY` in the frontend
- document env var setup in the Getting Started guide

## Testing
- `npx hardhat test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b5b7b80588333809f709c3057361c