### PR TITLE
Add UserSettingsManager contract

### DIFF
--- a/ado-core/contracts/UserSettingsManager.sol
+++ b/ado-core/contracts/UserSettingsManager.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+contract UserSettingsManager {
+    struct Settings {
+        bool autoClaim;
+        bool allowModAlerts;
+        bool extendRecoveryWindow;
+    }
+
+    mapping(address => Settings) public userSettings;
+
+    function updateSettings(bool _autoClaim, bool _allowModAlerts, bool _extendRecoveryWindow) external {
+        userSettings[msg.sender] = Settings({
+            autoClaim: _autoClaim,
+            allowModAlerts: _allowModAlerts,
+            extendRecoveryWindow: _extendRecoveryWindow
+        });
+    }
+
+    function getSettings(address user) external view returns (Settings memory) {
+        return userSettings[user];
+    }
+}

--- a/ado-core/test/UserSettingsManager.test.ts
+++ b/ado-core/test/UserSettingsManager.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+describe("UserSettingsManager", function () {
+  it("updates and returns settings for a user", async () => {
+    const [user, other] = await ethers.getSigners();
+
+    const Manager = await ethers.getContractFactory("UserSettingsManager");
+    const manager = await Manager.deploy();
+
+    await manager.connect(user).updateSettings(true, false, true);
+
+    const settings = await manager.getSettings(user.address);
+    expect(settings.autoClaim).to.equal(true);
+    expect(settings.allowModAlerts).to.equal(false);
+    expect(settings.extendRecoveryWindow).to.equal(true);
+
+    const otherSettingsBefore = await manager.getSettings(other.address);
+    expect(otherSettingsBefore.autoClaim).to.equal(false);
+    expect(otherSettingsBefore.allowModAlerts).to.equal(false);
+    expect(otherSettingsBefore.extendRecoveryWindow).to.equal(false);
+
+    await manager.connect(other).updateSettings(false, true, false);
+    const otherSettings = await manager.getSettings(other.address);
+    expect(otherSettings.autoClaim).to.equal(false);
+    expect(otherSettings.allowModAlerts).to.equal(true);
+    expect(otherSettings.extendRecoveryWindow).to.equal(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add new `UserSettingsManager` contract for on-chain preferences
- add Hardhat test covering settings update and retrieval

## Testing
- `npx hardhat test`
- `npx ts-node test/RetrnScoreEngine.test.ts` *(fails: ts-node dependencies missing)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686575612d548333be3c202f8882267b